### PR TITLE
chahua: P8.2 能力花名册 —— roster-a 手写 summary + roster-b LLM 生成缓存

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ transcript / cursor / summary 持久化保留。
 - 显式接力（handoff）：意愿打分之上的确定性指派通道。composer 底栏「指派」按钮弹一个统一面板，勾 1 位茶客 =「交给他发下一句」、勾 2~4 位 = 发起一场平行表态的圆桌（可选指定汇总人）；消息气泡上的「请审…」按钮另派一位茶客审阅该条消息。接力跑完即回到等用户输入、不回落打分；顶部「➡️ 下一句」队列条可整体取消（停当前 + 清后续）。茶客也能在发言里**提议**接力（指派 / 请审 / 圆桌），渲成「采纳 / 忽略」卡片，你点采纳后才生效。
 - 多行输入：Enter 发送、Shift+Enter 换行；textarea 自动撑高到 200px 切滚动。
 - 附件上传：composer 左侧 `+`，文件落房间共享目录，随下一条消息一起进上下文。
-- 任务房间：右上角面板「+ 新任务」开任务 → composer 顶部 chip 显示当前 active 任务；茶客感知 active 任务（onboarding/incremental prompt 都注入 task 块），可写 `./task/<name>` 自动归集为 artifact、可 propose 决策 / 新任务待你「采纳」。产物列表点击即下载（带白名单 + symlink 防逃逸）。多任务共存，单时刻最多 1 个 active。
+- 任务房间：右上角面板「+ 新任务」开任务 → composer 顶部 chip 显示当前 active 任务；茶客感知 active 任务（onboarding/incremental prompt 都注入 task 块），可写 `./task/<name>` 自动归集为 artifact、可 propose 决策 / 新任务 / 改任务状态（如达成时提议标记完成）待你「采纳」。产物列表点击即下载（带白名单 + symlink 防逃逸）。多任务共存，单时刻最多 1 个 active。
 - 调试抽屉：与任务面板互斥占右侧槽位，看每一轮谁被候选 / 分数 / 选谁 / prompt / 用了哪些工具 / 产物路径；切房 / 重启后仍能翻"开窗前"的历史 turn（点击索引行即拉详情）。默认开，盘上落到 `rooms/<id>/debug/`；`max_turns = 500` 按 turn 自动 rotation；`room.toml [debug] enabled = false` 可关。
 - 茶客能力查询：composer 里输 `/tools <茶客名>` / `/skills <茶客名>` 查某位茶客 agent 注册的工具 / 可用 skills（只读，结果显示为系统气泡，不进记录）；`/help` 看全部斜杠命令。
 - sidebar：切换房间 / 加茶客 / 导入 persona（本地目录或 GitHub）；点茶客头像设权限、勾选信任其 MCP。

--- a/chahua/admin_room.py
+++ b/chahua/admin_room.py
@@ -89,6 +89,8 @@ def _room_config_to_dict(rc: RoomConfig, paths: Paths) -> TomlSnapshot:
         }
         if gc.isolation != DEFAULT_ISOLATION:
             g["isolation"] = gc.isolation
+        if gc.summary:
+            g["summary"] = gc.summary
         if gc.llm is not None:
             g.update(_llm_spec_to_dict(gc.llm))
         if gc.extra_mcp_servers:

--- a/chahua/admin_toml.py
+++ b/chahua/admin_toml.py
@@ -36,6 +36,7 @@ class GuestSnapshot(TypedDict, total=False):
     persona: str
     permission: str
     isolation: str
+    summary: str  # P8.2-roster-a：一句话能力摘要；缺 / 空 = 不写
     # LLM 四件套（all-or-nothing：写 model 才允许 base_url / api_key_env / temperature，
     # 详见 chahua.llm_spec.LLMSpec.from_toml 校验）。temperature 是 float（非字符串），
     # render 时走 scalar literal —— 见 _render_llm_field。
@@ -63,7 +64,7 @@ class TomlSnapshot(TypedDict, total=False):
 
 # render 时认得的 guest 字段。
 _ALLOWED_GUEST_EMIT: frozenset[str] = (
-    frozenset({"name", "persona", "permission", "isolation", "extra_mcp_servers"})
+    frozenset({"name", "persona", "permission", "isolation", "summary", "extra_mcp_servers"})
     | frozenset(LLM_TOML_FIELDS)
 )
 
@@ -259,6 +260,8 @@ def _render_room_toml(snapshot: TomlSnapshot) -> str:
         # 让 [[guest]] 段读起来连成一块）；api_key_env 自己 11 字符，会占满。
         if "isolation" in g:
             lines.append(f"isolation  = {_toml_basic_string(str(g['isolation']))}")
+        if g.get("summary"):
+            lines.append(f"summary    = {_toml_basic_string(str(g['summary']))}")
         for key in LLM_TOML_FIELDS:
             if key in g:
                 lines.append(f"{key:<11}= {_render_llm_field(key, g[key])}")

--- a/chahua/config.py
+++ b/chahua/config.py
@@ -69,7 +69,7 @@ _ALLOWED_ROOM_KEYS: frozenset[str] = (
 # 在 LLMSpec.from_toml；这里只是顶层白名单。
 _ALLOWED_GUEST_KEYS: frozenset[str] = frozenset(
     {
-        "name", "persona", "permission", "isolation",
+        "name", "persona", "permission", "isolation", "summary",
         "model", "base_url", "api_key_env", "temperature",
         "extra_mcp_servers",
     }
@@ -150,6 +150,11 @@ class GuestConfig:
     llm: Optional[LLMSpec] = None
     """``[[guest]]`` 里写明的 ``model`` / ``base_url`` / ``api_key_env`` 解析结果；
     缺即走房间默认（:meth:`LLMSpec.from_env`）。P4.1 起每位茶客可独立配 client。"""
+
+    summary: Optional[str] = None
+    """``[[guest]].summary`` —— 一句话能力摘要（P8.2-roster-a）。手写可选字段；
+    onboarding 的 ``<room>`` 块「在场」行据此渲成带摘要的花名册，让茶客分工时看得见
+    别的茶客擅长什么。缺即 ``None``，「在场」行优雅降级为只列名字。"""
 
     extra_mcp_servers: Optional[dict[str, dict[str, Any]]] = None
     """房间级 inline MCP servers（``[[guest.extra_mcp_servers]]`` 数组表解析结果）。
@@ -624,6 +629,12 @@ def _build_guests(
             toml_path=toml_path,
         )
 
+        summary = _as_str(
+            g.get("summary"),
+            label=f"[[guest]] {name!r} summary",
+            toml_path=toml_path,
+        )
+
         out.append(
             GuestConfig(
                 name=name,
@@ -632,6 +643,7 @@ def _build_guests(
                 isolation=isolation_raw,
                 llm=guest_llm,
                 extra_mcp_servers=extra_mcp,
+                summary=summary or None,
             )
         )
 

--- a/chahua/context_renderer.py
+++ b/chahua/context_renderer.py
@@ -15,6 +15,7 @@ from typing import Optional
 from xml.sax.saxutils import quoteattr
 
 from .orchestrator_config import OrchestratorConfig
+from .persona_summary import clamp_summary
 from .room import Message, Room, format_messages
 from .summarizer import SummarySpan, Summarizer, TaskSummaries
 from .task import Task
@@ -59,6 +60,7 @@ class ContextRenderer:
         config: OrchestratorConfig,
         tasks_store: Optional[TasksStore] = None,
         task_summaries: Optional[TaskSummaries] = None,
+        roster: Optional[dict[str, str]] = None,
     ) -> None:
         self.room = room
         self.user_config = user_config
@@ -66,6 +68,10 @@ class ContextRenderer:
         self.config = config
         self.tasks_store = tasks_store
         self.task_summaries = task_summaries
+        # P8.2-roster-a：茶客名 → 一句话能力摘要。session 装配时一次性解析（手写
+        # [[guest]].summary 优先，缺则查中央缓存——roster-b）；运行期增删茶客会整体
+        # 重建 session，故 renderer 持的是不可变快照。仅 onboarding 的 <room> 块用。
+        self.roster = roster or {}
         self._display_for: Optional[dict[str, str]] = None
 
     def invalidate_display_cache(self) -> None:
@@ -201,6 +207,29 @@ class ContextRenderer:
             }
         return self._display_for
 
+    def _render_roster(self) -> str:
+        """``<room>`` 的「在场」行（P8.2-roster-a）。
+
+        任一茶客有摘要 → 渲成 bullet 花名册（无摘要的茶客只列名）；全员无摘要 →
+        退回逗号单行（roster-a 前的行为，优雅降级）。用户无摘要。
+        """
+        display_for = self.display_map()
+
+        def label(p: str) -> str:
+            name = display_for.get(p, p)
+            return f"{name}（人类用户）" if p == USER_SPEAKER_ID else name
+
+        entries = [
+            (label(p), clamp_summary(self.roster.get(p, "")))
+            for p in self.room.participants
+        ]
+        if not any(summary for _, summary in entries):
+            return "在场：" + ", ".join(name for name, _ in entries)
+        lines = ["在场："]
+        for name, summary in entries:
+            lines.append(f"- {name} —— {summary}" if summary else f"- {name}")
+        return "\n".join(lines)
+
     # ── XML 块拼装 ────────────────────────────────────────────────────
 
     def _render_onboarding(
@@ -220,11 +249,6 @@ class ContextRenderer:
         裁剪；``<order_hint>`` 与 ``<current_task>`` 同生共灭。
         """
         display_for = self.display_map()
-
-        def label(p: str) -> str:
-            name = display_for.get(p, p)
-            return f"{name}（人类用户）" if p == USER_SPEAKER_ID else name
-
         blocks: list[str] = []
 
         # 属性值走 quoteattr 转义 —— room.name / display_name 来自用户配置，含 `"` / `<` /
@@ -235,7 +259,7 @@ class ContextRenderer:
             room_lines.append(f"话题：{self.room.topic}")
         if self.room.rules:
             room_lines.append(f"规则：{self.room.rules}")
-        room_lines.append("在场：" + ", ".join(label(p) for p in self.room.participants))
+        room_lines.append(self._render_roster())
         room_lines.append("</room>")
         blocks.append("\n".join(room_lines))
 

--- a/chahua/orchestrator.py
+++ b/chahua/orchestrator.py
@@ -125,6 +125,7 @@ class Orchestrator:
         tasks_store: Optional[TasksStore] = None,
         task_summaries: Optional[TaskSummaries] = None,
         recorder: TurnRecorder = NOOP_RECORDER,
+        roster: Optional[dict[str, str]] = None,
     ) -> None:
         self.room = room
         self.user_config = user_config
@@ -162,6 +163,7 @@ class Orchestrator:
             config=config,
             tasks_store=tasks_store,
             task_summaries=task_summaries,
+            roster=roster,
         )
         # 后台摘要任务：每轮发言后被 ``_kick_summarize`` 启动；下次再 kick 时如果还在跑
         # 就跳过，避免堆积。摘要慢点不影响当前回合，所以**不 await**。

--- a/chahua/persona_summary.py
+++ b/chahua/persona_summary.py
@@ -1,0 +1,172 @@
+"""P8.2-roster-b：persona 能力摘要 —— LLM 生成 + 中央内容寻址缓存。
+
+把 ``<room>`` 花名册的摘要来源扩成三级：手写 ``[[guest]].summary``（roster-a）→
+本模块的 LLM 生成缓存 → 只列名字。**LLM 生成只是「补全缓存」的旁路** —— 不阻塞
+boot、缓存命中零 LLM 调用。
+
+缓存按 persona md 内容 hash 寻址（值含 ``gen_version``），落
+``user_data_root/.chahua/persona-summaries/<hash>.json``：
+
+- 内容寻址 → persona 改了 hash 变、自动失效重生成；同一 persona 多房间共用只生成一次。
+- 落在可写的 ``user_data_root`` → bundled persona（``app_root`` 只读）也能缓存。
+- ``GEN_VERSION`` 是模块常量；改生成 prompt 时 bump，旧缓存读出 version 不匹配即视作
+  miss、自动重生成。
+
+所有失败（无凭据 / 网络 / 解析 / IO）一律 WARN + 退回「无摘要」，**绝不抛、不阻断
+房间**（与「recorder / rotation 失败不阻断房间」同口径）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+from agentao.llm import LLMClient
+
+from ._llm_oneshot import chat_oneshot
+from ._paths import Paths
+from ._persist import write_json_atomic
+
+_log = logging.getLogger(__name__)
+
+# 生成 prompt / 口径变更时 bump —— 旧缓存读出 gen_version 不匹配即视作 miss、自动重生成。
+GEN_VERSION = 1
+
+# 摘要硬上限：一行、≤ 该字数。<room> 花名册每位一行，长句会撑破版式。手写摘要
+# （roster-a）与 LLM 生成结果共用同一上限。
+SUMMARY_MAXLEN = 40
+
+_CACHE_SUBPATH = (".chahua", "persona-summaries")
+_GEN_MAX_TOKENS = 80
+# prompt 里的「30 字」是软目标；SUMMARY_MAXLEN=40 是 clamp_summary 的硬兜底 —— 留 10 字
+# 裕度容忍 LLM 略超，超出仍会被截断。
+_SYSTEM_PROMPT = (
+    "你在为一个多人聊天室生成「能力花名册」。下面是某位参与者的人设卡。"
+    "请用一句话（中文、不超过 30 字、结尾不加标点）概括 ta 最核心的能力或职责，"
+    "供房间里其他人分工时参考。只输出这一句话本身，不要解释、不要加引号。"
+)
+
+
+def clamp_summary(s: str) -> str:
+    """取首行 + 截断到 :data:`SUMMARY_MAXLEN` 字。空串安全返空。
+
+    手写摘要（roster-a）与 LLM 生成结果共用 —— 单点保证 ``<room>`` 花名册每位一行。
+    """
+    line = s.strip().split("\n", 1)[0].strip()
+    if len(line) > SUMMARY_MAXLEN:
+        return line[:SUMMARY_MAXLEN] + "…"
+    return line
+
+
+def persona_hash(persona_md: str) -> str:
+    """persona md 全文 sha256 hex —— 内容寻址缓存键。"""
+    return hashlib.sha256(persona_md.encode("utf-8")).hexdigest()
+
+
+def _cache_path(paths: Paths, h: str) -> Path:
+    return paths.user_data_root.joinpath(*_CACHE_SUBPATH, f"{h}.json")
+
+
+def read_cached_summary(paths: Paths, persona_md: str) -> Optional[str]:
+    """中央缓存查 persona 摘要。命中且 ``gen_version`` 匹配 → 摘要字符串；否则
+    （miss / stale / 损坏 / IO 错）→ ``None``。读路径绝不抛。"""
+    path = _cache_path(paths, persona_hash(persona_md))
+    # 故意不走 _persist.read_json_or_none —— 它对坏 JSON 会 WARN；缓存文件损坏是良性
+    # 事件（重新生成即可），静默 miss 不该惊扰用户。
+    try:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(obj, dict) or obj.get("gen_version") != GEN_VERSION:
+        return None
+    summary = obj.get("summary")
+    return summary if isinstance(summary, str) and summary else None
+
+
+def _write_cache(paths: Paths, h: str, summary: str) -> None:
+    path = _cache_path(paths, h)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_json_atomic(path, {"gen_version": GEN_VERSION, "summary": summary})
+    except OSError:
+        _log.warning("persona summary 缓存写入失败：%s", path, exc_info=True)
+
+
+def resolve_guest_summary(
+    handwritten: Optional[str], persona_md: str, *, paths: Paths
+) -> Optional[str]:
+    """花名册摘要三级解析：手写 ``[[guest]].summary`` → 中央缓存 → ``None``。
+
+    手写优先且**不触发任何 LLM / 缓存查**。返回 ``None`` 表示该 persona 还没摘要 ——
+    调用方据此把它列进后台生成候选。
+    """
+    if handwritten:
+        return handwritten
+    return read_cached_summary(paths, persona_md)
+
+
+async def generate_persona_summary(persona_md: str, *, llm: LLMClient) -> str:
+    """让 LLM 读 persona md 产一句话能力摘要。失败 / 空 → ``""``（``chat_oneshot``
+    已对所有异常兜底）。"""
+    raw = await chat_oneshot(
+        llm,
+        [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": persona_md},
+        ],
+        max_tokens=_GEN_MAX_TOKENS,
+        log_label="persona summary",
+    )
+    return clamp_summary(raw)
+
+
+async def _ensure_cached(
+    persona_md: str, *, paths: Paths, llm: LLMClient, label: str
+) -> None:
+    """单 persona 后台生成：缓存已命中（并发房间已写 / 本就有）即返回，否则生成 +
+    写缓存。全程不抛 —— 作为裸 task 跑，异常逃逸会触发 asyncio 警告。"""
+    if read_cached_summary(paths, persona_md) is not None:
+        return
+    summary = await generate_persona_summary(persona_md, llm=llm)
+    if summary:
+        _write_cache(paths, persona_hash(persona_md), summary)
+        _log.info("persona summary 已生成并缓存：%s —— %s", label, summary)
+
+
+# 在跑的后台生成 task，按 persona hash 索引：① 多房间并发调度同一 persona 只跑一次
+# ② 持 task 引用防 GC（asyncio 不持引用的 task 可能被中途回收）。
+_inflight: dict[str, "asyncio.Task[None]"] = {}
+
+
+def schedule_generation(
+    items: list[tuple[str, str]], *, paths: Paths, llm: LLMClient
+) -> None:
+    """后台预热若干 persona 的摘要缓存。``items`` = ``[(persona_md, label), ...]``。
+
+    无运行中的 event loop（如 sync 测试装配）→ WARN 跳过、不抛。已命中缓存 / 已在跑
+    的同一 persona 跳过。生成在后台 task 跑，不阻塞调用方 —— 房间装配 / boot 不被 LLM
+    拖慢；摘要在下一次重建 session 时才进 ``<room>``（见 docs/P8 §5.3）。
+    """
+    if not items:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        _log.warning(
+            "persona summary：无运行 event loop，跳过 %d 个 persona 的摘要预热",
+            len(items),
+        )
+        return
+    for persona_md, label in items:
+        h = persona_hash(persona_md)
+        if h in _inflight or read_cached_summary(paths, persona_md) is not None:
+            continue
+        task = loop.create_task(
+            _ensure_cached(persona_md, paths=paths, llm=llm, label=label)
+        )
+        _inflight[h] = task
+        task.add_done_callback(lambda t, h=h: _inflight.pop(h, None))

--- a/chahua/session.py
+++ b/chahua/session.py
@@ -25,6 +25,7 @@ from .cursor import GuestCursor
 from .debug_recorder import TurnRecorder
 from .guest import TeaGuest
 from .llm_spec import LLMSpec, build_client
+from . import persona_summary
 from .orchestrator import Orchestrator, OrchestratorConfig
 from .persona_assets import discover_assets, persona_relative
 from .room import Room
@@ -444,6 +445,25 @@ def build_room_session(
         room_config.orchestrator_overrides, explicit=orchestrator_config
     )
 
+    # P8.2-roster：花名册摘要三级解析 —— 手写 [[guest]].summary（roster-a）→ 中央
+    # 内容寻址缓存（roster-b）→ 无。运行期增删茶客整体重建 session，故装配期一次性
+    # 解析成不可变快照传给 orchestrator / renderer。仍 miss 的 persona 列进后台生成
+    # 候选，schedule_generation 在有 event loop 时预热缓存（不阻塞 boot；摘要下次
+    # 重建 session 才进 <room>）。
+    roster: dict[str, str] = {}
+    summary_pending: list[tuple[str, str]] = []
+    for gc, (_guest, persona_md) in zip(room_config.guests, guest_entries):
+        summary = persona_summary.resolve_guest_summary(
+            gc.summary, persona_md, paths=paths
+        )
+        if summary:
+            roster[gc.name] = summary
+        else:
+            summary_pending.append((persona_md, gc.name))
+    persona_summary.schedule_generation(
+        summary_pending, paths=paths, llm=summary_client
+    )
+
     orchestrator = Orchestrator(
         room=room,
         user_config=user_config,
@@ -454,6 +474,7 @@ def build_room_session(
         tasks_store=tasks_store,
         task_summaries=task_summaries,
         recorder=recorder,
+        roster=roster,
     )
     for guest, persona_md in guest_entries:
         orchestrator.register(guest, persona_md)

--- a/docs/P8-任务管理 skill 与原生化.md
+++ b/docs/P8-任务管理 skill 与原生化.md
@@ -188,34 +188,33 @@ room snapshot + `admin_toml.py`（`summary` 进 round-trip，P4「配置闭环�
    —— 摘要只进 onboarding 的 `<room>`、不进每轮 `<room_update>`（§5.2），后台补好
    缓存也不会即时刷进进行中的会话窗口。
 
-**生成时机 —— 首选「导入角色时」预热**：
+**生成时机 —— 房间装配（`build_room_session`，已落地口径）**：
 
-- **导入角色时（首选触发点）** —— persona 导入走 server 的 async inbound
-  （`server_inbound_io` 的 persona import 路径），那里**有运行中的 event loop +
-  runtime 调度器**，是最干净的生成点。导入完成后、**当 LLM available 时**立即
-  `schedule_persona_summary_generation(...)` 把摘要预生成进中央缓存 —— 这样该 persona
-  首次被拉进任何房间，`<room>` 一上来就直接命中缓存、有摘要，不必等「下一次
-  onboarding」。
-- **加 / 改 guest persona 时** —— `admin_guest` 同属 server async 上下文，同口径调度。
-- **房间装配兜底** —— `build_room_session` 对中央缓存仍 miss 的 persona（随包 bundled、
-  手放、或导入时 LLM 不可用）请求一次生成，走 `schedule_persona_summary_generation`
-  间接层（不直接 `create_task`）。
+- `build_room_session` 解析花名册时，对手写与缓存**都 miss** 的 persona 收集成候选，
+  调 `persona_summary.schedule_generation(...)` 后台预热中央缓存。生成在后台 task 跑，
+  不阻塞装配 / boot；摘要在**下一次重建 session** 时进 `<room>`（见「摘要解析」第 5 步）。
+- **admin 加 / 改 guest 自动覆盖** —— admin 改 guest 走 `_replace_session` → 重跑
+  `build_room_session`，装配触发点天然覆盖，无需单独 hook。
+- **persona 导入暂不单独预热** —— 导入只落 persona 文件、不动当前房间；该 persona 被
+  加进任何房间时由装配触发点补缓存。「导入即预热」是纯延迟优化（少等一次重建），
+  本期不做，留作后续 follow-up。
 
-**「当 LLM available」是所有触发点的统一前置**：LLM 未配置 / 不可达 / 无调度器环境
-→ 跳过生成 + WARN，摘要留空、`<room>` 退回只列名字，等下一个 LLM available 的触发点
-（含下次导入 / 改 persona / 房间装配）再补。导入是**最早**的那个机会，但不是唯一。
+设计早期版本想做「导入时 / admin 时」独立预热 hook + 注入式
+`schedule_persona_summary_generation` 间接层。落地时收敛掉 —— 见下方工程契约。
 
 工程契约 —— 把评审担心的复杂度写实：
 
 - **不改 `build_room_session` 为 async** —— 现有 `build_room_session` 是同步函数，
   为摘要生成把它异步化会逼整条房间装配链路异步化、改动面失控。
-- **后台生成走单一调度口径，不在 session 层直接 `create_task`** —— `build_room_session`
-  是同步函数，装配期通常**没有运行中的 event loop**，直接 `asyncio.create_task` 会
-  抛 `RuntimeError`。收窄成一个口径：由 server / runtime 层提供
-  `schedule_persona_summary_generation(...)`，`session.py` / `admin_guest.py` 只
-  **请求调度**、不自己起 task；无调度器环境（如纯 CLI oneshot）→ 跳过生成 + WARN，
-  `<room>` 就只列名字。**不**用 `asyncio.gather` 嵌进同步装配链。第一版调度器内
-  **串行后台生成**也可接受（N 个 guest 排队，反正不阻塞 boot）。
+- **后台生成走 `schedule_generation` + `get_running_loop()` 守卫，不需注入式调度层**
+  —— `build_room_session` 是同步函数，但它的三个调用点（CLI `_repl` /
+  `server_entry._serve` / `server._replace_session`）**实测都在 `async def` 内**，运行期
+  必有 event loop。`persona_summary.schedule_generation` 内 `asyncio.get_running_loop()`
+  守卫：有 loop → `create_task` 后台生成；无 loop（sync 单测装配）→ WARN 跳过、不抛。
+  实跑都会预热，sync 单测优雅降级。早期设计的注入式 `schedule_persona_summary_
+  generation(...)` 间接层被这条守卫取代 —— 既然实跑必有 loop，间接层是多余抽象。
+  后台 task 持引用（模块级 `_inflight` dict）防 GC、按 persona hash 去重（多房间并发
+  调度同一 persona 只跑一次）。**不**用 `asyncio.gather` 嵌进同步装配链。
 - **boot 不被 LLM 强依赖** —— 缓存 miss 时房间照常启动、`<room>` 先只列名字；摘要
   在后台补，**下一次 onboarding** 才生效（见上「摘要解析」第 5 步）。首轮可能只有
   名字，**接受**。
@@ -228,22 +227,21 @@ room snapshot + `admin_toml.py`（`summary` 进 round-trip，P4「配置闭环�
   被多个房间用只生成一次（content-addressed 天然去重）。persona 改了 hash 变 → 自动
   失效重生成；`gen_version` 是模块常量，改生成 prompt 时 bump 一次即让所有旧缓存
   失效。缓存是 **cache**（可重生成、丢了不影响正确性），不算「冗余 state」。
-- **生成用 summary effective spec，不承诺 cheap** —— 复用 `[summary]` section 解析
-  出的 effective LLM spec（缺则按 fallback 链到 scoring / 房间默认）。`[summary]` 只是
-  「摘要模型」配置位、**不保证便宜**，成本取决于用户怎么配；文档不承诺 cheap，避免
-  启动期自动生成出成本 surprise。
-- **失败只 WARN、不 NOTICE、不阻断房间** —— 单 guest 生成失败（无 key / 网络 /
-  解析）→ 退回只列名字 + WARN，不弹 NOTICE、不阻断 boot（与「recorder / rotation
-  失败不阻断房间」同口径）。
+- **生成用 summary effective spec 的已建 client，不另建** —— 复用 `build_room_session`
+  装配期已建好的 `summary_client`（`[summary]` → scoring → 房间默认 fallback 链）。
+  **不另 `build_client`** —— agentao `LLMClient.__init__` 会 evict 共享 logger 的文件
+  handler，多建一份会静默 detach 茶客日志。`[summary]` 不保证便宜，文档不承诺 cheap。
+- **失败只 WARN、不 NOTICE、不阻断房间** —— 生成失败（无 key / 网络 / 解析）→ 退回
+  只列名字 + WARN，不弹 NOTICE、不阻断 boot（与「recorder / rotation 失败不阻断房间」
+  同口径）。`chat_oneshot` 对所有异常兜底返 `""`。
 
-落地点：新增 persona 摘要生成 + 中央缓存模块（LLM 调用、内容 hash 键、失败兜底）/
-server / runtime 层提供 `schedule_persona_summary_generation(...)` 调度入口 /
-`server_inbound_io`（persona 导入路径，LLM available 时请求预热）+ `admin_guest.py`
-（加 / 改 guest 后请求调度）+ `session.py`（装配兜底，对仍 miss 的 persona 请求调度；
-不直接 `create_task`、不改 sync 签名；无调度器环境跳过 + WARN）/ `context_renderer.py`
-（`在场` 行解析按三级 fallback）。测试：缓存命中不重跑 LLM / persona 改动 hash 失效 /
-生成失败退名字 / 缓存 miss 时 `<room>` 先只列名字 / 无调度器或 LLM 不可用时跳过生成
-不报错 / **导入角色后中央缓存被预热**。
+落地点（已实现）：新增 `persona_summary.py`（内容 hash / 中央缓存读写 / LLM 生成 /
+`schedule_generation` / `resolve_guest_summary` 三级解析）+ `session.py`
+（`build_room_session` 解析花名册 + 调 `schedule_generation` 预热）+ `context_renderer.py`
+（`clamp_summary` 单点共用、`<room>` 在场行按 roster dict 渲染）。测试
+`tests/test_persona_summary.py`：内容寻址 hash / 缓存 round-trip / `gen_version` 失效 /
+损坏视作 miss / 三级解析 / LLM 生成 + 截断 / `schedule_generation` 无 loop 跳过 / 有 loop
+写缓存 / 已缓存不重跑。
 
 这套机制有工程量，但**不进 task tool、不影响 P8.2 的 `task_propose_status`、不改房间
 装配链路为 async、不改回合模型**；稳态缓存命中时不调用 LLM。
@@ -302,6 +300,6 @@ P8.2 落地后，`SKILL.md` Step 5「判断 Goal」可补一句：达成时用 `
 | --- | --- | --- |
 | **P8.1** | `examples/skill/task-management/SKILL.md` 茶客侧任务管理 skill，零后端改动 | 已落地 |
 | **P8.2** | `task_propose_status` 工具 + `TASK_PROPOSAL_KIND_STATUS` flat kind + `proposal_card.js` 一个 `status` 分支（采纳按终结态分流 `update_task` / `close_task`）+ SKILL.md Step 5 跟进 + 测试（两类状态各覆盖） | 已落地 |
-| **P8.2-roster-a** | 能力花名册（§5.2）—— 可选 `[[guest]].summary` room.toml 字段（走 P4 配置闭环四点）+ `context_renderer.py` 的 `<room>` 渲染（手写摘要 / 退回名字两级）。可独立完整落地、不依赖 LLM | 设计中 |
-| **P8.2-roster-b** | LLM 生成缓存（§5.3）—— persona 摘要经 `schedule_persona_summary_generation` 后台生成，落 `user_data_root` 中央内容寻址缓存。**首选触发点：导入角色时**（LLM available 即预热），admin 改 persona / 房间装配为兜底。不改 `build_room_session` 为 async、boot 不强依赖 LLM、缓存命中零调用 | 设计中 |
+| **P8.2-roster-a** | 能力花名册（§5.2）—— 可选 `[[guest]].summary` room.toml 字段（走 P4 配置闭环四点）+ `context_renderer.py` 的 `<room>` 渲染（手写摘要 / 退回名字两级）。不依赖 LLM | 已落地 |
+| **P8.2-roster-b** | LLM 生成缓存（§5.3）—— `persona_summary.py`：persona 摘要后台生成、落 `user_data_root` 中央内容寻址缓存（hash 键 + `gen_version`）。`build_room_session` 装配时对缓存 miss 的 persona 调 `schedule_generation` 预热（`get_running_loop()` 守卫，无 loop 跳过）。`build_room_session` 不改 async、boot 不阻塞、缓存命中零调用 | 已落地 |
 | **P8.3** | 原生自动推进 —— 「managed task session」运行态（§6 草案） | 未规划 |

--- a/tests/test_persona_summary.py
+++ b/tests/test_persona_summary.py
@@ -1,0 +1,152 @@
+"""P8.2-roster-b：persona 摘要 LLM 生成 + 中央内容寻址缓存。
+
+覆盖：① 内容寻址 hash ② 缓存读写 round-trip / gen_version 失效 / 损坏视作 miss
+③ 三级解析（手写 → 缓存 → 无）④ LLM 生成 + 截断 ⑤ schedule 无 loop 跳过 / 有
+loop 写缓存。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from chahua import persona_summary
+from chahua._paths import Paths
+
+
+# ─── fake LLMClient（chat_oneshot 只用 resp.choices[0].message.content）──────
+
+
+class _FakeLLM:
+    def __init__(self, content: str = "擅长成本测算与预算评审") -> None:
+        self._content = content
+        self.calls = 0
+
+    def chat(self, *, messages, max_tokens):  # noqa: ANN001 - 测试替身
+        self.calls += 1
+        msg = type("M", (), {"content": self._content})()
+        choice = type("C", (), {"message": msg})()
+        return type("R", (), {"choices": [choice]})()
+
+
+def _paths(tmp_path: Path) -> Paths:
+    return Paths(app_root=tmp_path, user_data_root=tmp_path)
+
+
+# ─── ① 内容寻址 hash ────────────────────────────────────────────────────────
+
+
+def test_persona_hash_stable_and_content_sensitive():
+    md = "# 范总\n擅长成本测算"
+    assert persona_summary.persona_hash(md) == persona_summary.persona_hash(md)
+    assert persona_summary.persona_hash(md) != persona_summary.persona_hash(md + "x")
+
+
+# ─── ② 缓存读写 ─────────────────────────────────────────────────────────────
+
+
+def test_read_cached_summary_miss_returns_none(tmp_path):
+    assert persona_summary.read_cached_summary(_paths(tmp_path), "# 范总") is None
+
+
+def test_cache_round_trip(tmp_path):
+    paths, md = _paths(tmp_path), "# 范总\n擅长成本测算"
+    persona_summary._write_cache(paths, persona_summary.persona_hash(md), "成本专家")
+    assert persona_summary.read_cached_summary(paths, md) == "成本专家"
+
+
+def test_cache_gen_version_mismatch_is_miss(tmp_path):
+    paths, md = _paths(tmp_path), "# 范总"
+    path = persona_summary._cache_path(paths, persona_summary.persona_hash(md))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"gen_version": persona_summary.GEN_VERSION + 99, "summary": "旧"}),
+        encoding="utf-8",
+    )
+    assert persona_summary.read_cached_summary(paths, md) is None
+
+
+def test_cache_corrupt_file_is_miss(tmp_path):
+    paths, md = _paths(tmp_path), "# 范总"
+    path = persona_summary._cache_path(paths, persona_summary.persona_hash(md))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    assert persona_summary.read_cached_summary(paths, md) is None
+
+
+# ─── ③ 三级解析 ─────────────────────────────────────────────────────────────
+
+
+def test_resolve_handwritten_wins(tmp_path):
+    """手写优先 —— 即使缓存有别的值也用手写。"""
+    paths, md = _paths(tmp_path), "# 范总"
+    persona_summary._write_cache(paths, persona_summary.persona_hash(md), "缓存值")
+    assert persona_summary.resolve_guest_summary("手写值", md, paths=paths) == "手写值"
+
+
+def test_resolve_falls_through_to_cache(tmp_path):
+    paths, md = _paths(tmp_path), "# 范总"
+    persona_summary._write_cache(paths, persona_summary.persona_hash(md), "缓存值")
+    assert persona_summary.resolve_guest_summary(None, md, paths=paths) == "缓存值"
+
+
+def test_resolve_both_miss_returns_none(tmp_path):
+    assert persona_summary.resolve_guest_summary(None, "# 范总", paths=_paths(tmp_path)) is None
+
+
+# ─── ④ LLM 生成 + 截断 ──────────────────────────────────────────────────────
+
+
+async def test_generate_persona_summary(tmp_path):
+    out = await persona_summary.generate_persona_summary(
+        "# 范总\n做成本测算", llm=_FakeLLM("擅长成本测算")
+    )
+    assert out == "擅长成本测算"
+
+
+async def test_generate_clamps_long_output(tmp_path):
+    out = await persona_summary.generate_persona_summary(
+        "# 范总", llm=_FakeLLM("能" * 60)
+    )
+    assert out == "能" * persona_summary.SUMMARY_MAXLEN + "…"
+
+
+def test_clamp_summary_first_line_and_truncation():
+    assert persona_summary.clamp_summary("  第一行\n第二行  ") == "第一行"
+    assert persona_summary.clamp_summary("能" * 100) == "能" * 40 + "…"
+    assert persona_summary.clamp_summary("") == ""
+
+
+# ─── ⑤ schedule_generation ──────────────────────────────────────────────────
+
+
+def test_schedule_generation_no_loop_skips(tmp_path):
+    """sync 上下文无 event loop → WARN 跳过、不抛、不写缓存。"""
+    paths, md = _paths(tmp_path), "# 范总"
+    persona_summary.schedule_generation(
+        [(md, "范总")], paths=paths, llm=_FakeLLM()
+    )
+    assert persona_summary.read_cached_summary(paths, md) is None
+
+
+async def test_schedule_generation_writes_cache(tmp_path):
+    paths, md = _paths(tmp_path), "# 范总\n擅长成本测算"
+    llm = _FakeLLM("成本测算专家")
+    persona_summary.schedule_generation([(md, "范总")], paths=paths, llm=llm)
+
+    tasks = list(persona_summary._inflight.values())
+    assert tasks, "应已起后台生成 task"
+    for t in tasks:
+        await t
+
+    assert persona_summary.read_cached_summary(paths, md) == "成本测算专家"
+
+
+async def test_schedule_generation_skips_already_cached(tmp_path):
+    """缓存已命中 → 不再起 task、不调 LLM。"""
+    paths, md = _paths(tmp_path), "# 范总"
+    persona_summary._write_cache(paths, persona_summary.persona_hash(md), "已有")
+    llm = _FakeLLM()
+    persona_summary.schedule_generation([(md, "范总")], paths=paths, llm=llm)
+    assert persona_summary.persona_hash(md) not in persona_summary._inflight
+    assert llm.calls == 0

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1,0 +1,111 @@
+"""P8.2-roster-a：手写 ``[[guest]].summary`` 能力花名册。
+
+覆盖：① config 解析 summary 字段 ② ``<room>`` 在场行带摘要渲成 bullet 花名册
+③ 全员无摘要 → 退回逗号单行 ④ 长摘要硬截断 ⑤ toml round-trip 不丢 summary。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chahua import admin
+from chahua.admin_room import _room_config_to_dict
+from chahua.admin_toml import _render_room_toml
+from chahua.config import load_room_config
+from chahua.cursor import GuestCursor
+from chahua.orchestrator import Orchestrator, OrchestratorConfig
+from chahua.room import Room
+from chahua.user_md import USER_SPEAKER_ID, UserConfig
+
+from conftest import NoopScorer, NoopSummarizer
+
+
+def _seed_room(env_paths):
+    return admin.create_room(
+        paths=env_paths, room_id="roster-cfg", name="roster test",
+        guests=[{"persona": "chahua/personas/宝总.md", "name": "宝总"}],
+    )
+
+
+def _write_toml(rc, guest_extra: str) -> None:
+    (rc.room_dir / "room.toml").write_text(
+        '[room]\nname = "x"\n\n[[guest]]\nname = "宝总"\n'
+        'persona = "chahua/personas/宝总.md"\npermission = "read-only"\n'
+        + guest_extra,
+        encoding="utf-8",
+    )
+
+
+# ─── ① config 解析 ──────────────────────────────────────────────────────────
+
+
+def test_guest_summary_parsed(env_paths):
+    rc = _seed_room(env_paths)
+    _write_toml(rc, 'summary = "擅长成本测算与预算评审"\n')
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    assert rc2.guests[0].summary == "擅长成本测算与预算评审"
+
+
+def test_guest_summary_absent_is_none(env_paths):
+    rc = _seed_room(env_paths)
+    _write_toml(rc, "")
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    assert rc2.guests[0].summary is None
+
+
+# ─── ②③④ <room> 在场行渲染 ─────────────────────────────────────────────────
+
+
+def _build_orch(*, roster=None, guests=("范总", "汪小姐")) -> Orchestrator:
+    room = Room(name="黄河路")
+    room.add_participant(USER_SPEAKER_ID)
+    for g in guests:
+        room.add_participant(g)
+    return Orchestrator(
+        room=room,
+        user_config=UserConfig(display_name="老金", full_md=None, source=None),
+        scorer=NoopScorer(),
+        summarizer=NoopSummarizer(),
+        cursor=GuestCursor(),
+        config=OrchestratorConfig(onboarding_threshold=20),
+        roster=roster,
+    )
+
+
+def test_room_block_renders_summary_roster():
+    orch = _build_orch(roster={"范总": "擅长成本测算"})
+    ctx = orch._build_context_for("范总", task_id=None)
+    assert "在场：\n-" in ctx            # 有摘要 → bullet 花名册
+    assert "- 范总 —— 擅长成本测算" in ctx
+    assert "- 汪小姐" in ctx            # 无摘要的茶客只列名
+    assert "- 老金（人类用户）" in ctx   # 用户无摘要、不带 ——
+
+
+def test_room_block_no_summary_falls_back_to_comma():
+    orch = _build_orch(roster=None)
+    ctx = orch._build_context_for("范总", task_id=None)
+    assert "在场：老金（人类用户）, 范总, 汪小姐" in ctx
+
+
+def test_room_summary_truncated():
+    orch = _build_orch(roster={"范总": "能" * 60})
+    ctx = orch._build_context_for("范总", task_id=None)
+    assert "能" * 40 + "…" in ctx
+    assert "能" * 41 not in ctx
+
+
+# ─── ⑤ toml round-trip ──────────────────────────────────────────────────────
+
+
+def test_summary_round_trips_through_toml(env_paths):
+    rc = _seed_room(env_paths)
+    _write_toml(rc, 'summary = "擅长成本测算与预算评审"\n')
+    rc1 = load_room_config(rc.room_dir, paths=env_paths)
+
+    text = _render_room_toml(_room_config_to_dict(rc1, env_paths))
+    assert "擅长成本测算与预算评审" in text
+
+    # 重写回盘后再解析，summary 不丢
+    (rc.room_dir / "room.toml").write_text(text, encoding="utf-8")
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    assert rc2.guests[0].summary == "擅长成本测算与预算评审"


### PR DESCRIPTION
## 做什么

茶客分工时看得见别的茶客擅长什么 —— onboarding 的 `<room>` 块「在场」行从只列名字扩成带一句话能力摘要的**花名册**。

## roster-a：手写 `[[guest]].summary`

- `room.toml` 的 `[[guest]]` 新增**可选** `summary` 字段，走 P4 配置闭环四点（`config.py` 解析 / `_room_config_to_dict` snapshot / `_render_room_toml` 回写 / CLAUDE.md 不变量）。
- `<room>` 在场行渲染：任一茶客有摘要 → bullet 花名册（无摘要的只列名）；全员无摘要 → 退回逗号单行（= 改动前行为，优雅降级）。
- 只进 onboarding 的 `<room>`，**不**进每轮 `<room_update>`（稳定信息，避免 N×T token 放大）。
- `roster` 装配期一次性解析成不可变快照，经 `Orchestrator` 透传 `ContextRenderer`（运行期增删茶客整体重建 session）。

## roster-b：LLM 生成 + 中央缓存

- 新增 `chahua/persona_summary.py` —— persona md **内容寻址**中央缓存（`user_data_root/.chahua/persona-summaries/<sha256>.json`，值含 `gen_version`）。
- `resolve_guest_summary` 三级解析：手写 `[[guest]].summary` → 中央缓存 → 无。
- `build_room_session` 对手写与缓存都 miss 的 persona 调 `schedule_generation` 后台预热；`get_running_loop()` 守卫（无 loop 的 sync 测试跳过），生成在后台 task 跑、**不阻塞 boot**、缓存命中**零 LLM 调用**。
- 失败一律 WARN、不阻断房间；`clamp_summary`（一行 ≤40 字）单点共用。

## 设计落地说明

生成触发点收敛为「房间装配」单一口径 —— `build_room_session` 三个调用点实测都在 `async def` 内、运行期必有 event loop，`get_running_loop()` 守卫即够，取代早期设计的注入式 `schedule_persona_summary_generation` 间接层。admin 改 guest 走 `_replace_session` 重跑装配天然覆盖；persona 导入即预热属纯延迟优化，留作 follow-up。详见 `docs/P8` §5.3。

## 测试

`tests/test_roster.py`（6）+ `tests/test_persona_summary.py`（14），全仓 812 测通过。`/simplify` 多 agent 评审 + `/codex:review` 均无遗留问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)