### PR TITLE
chahua: release prep v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-05-21
+
+详见 [`docs/releases/v0.1.2.md`](docs/releases/v0.1.2.md)。
+
 ### Added
 - **P8.3 原生自动推进 —— 托管任务会话（MTS）**（2026-05-21，详见 [`docs/P8.3-原生自动推进.md`](docs/P8.3-原生自动推进.md)）：让「管理者茶客指派 → 被指派茶客执行 → 控制权**自动回到管理者**复查 → 再指派」闭环自己转起来，不必每一步都等用户敲消息或点「采纳」。用户在任务面板**显式开启**一段有预算上限的「托管任务会话」（Managed Task Session, **MTS**），授权某位管理者茶客在预算内自主推进、随时可停。**纯调度层增量**：复用 P7 的 handoff drain loop / `HandoffItem` / cap / `_run_handoff_turn` wrapper，复用 P7.4 的 propose 工具（工具面零改动），复用 P5 的 Task 模型——不改对话原语、不改 Task 数据结构、不引结构化 `plan_items`、不新开调度路径、不新增管理者专用工具。设计经三轮评审收敛（v3）。
   - **运行态**（P8.3.1）。`chahua/handoff.py` 加 `ManagedSession` dataclass（`task_id` / `manager_guest` / `budget`）+ `MAX_MANAGED_BUDGET = 20` / `MANAGED_SESSION_DEFAULT_BUDGET = 6` 常量。挂 `Orchestrator._managed_session`，与 `_handoff_queue` 同瞬态语义——不落盘、crash / 切房 / `reset_room` 即清，`None` 即「无托管」（不另存 `enabled` bool）。单房间最多 1 个。`events.py` / `events.js` 加 3 个 hint 型事件类型 `managed_session_started` / `managed_session_advanced` / `managed_session_ended`（`schema_version` 不 bump）。

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.2-dev",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.2-dev",
+      "version": "0.1.2",
       "dependencies": {
         "dompurify": "^3.4.3",
         "marked": "^18.0.3"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.2-dev",
+  "version": "0.1.2",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.2.dev0"
+__version__ = "0.1.2"

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -1,0 +1,54 @@
+# v0.1.2 —— 显式 handoff + 任务管理与原生自动推进（2026-05-21）
+
+继 v0.1.1「任务房间 + 调试与回放」之后第三个版本。本版把房间从「茶客各自接话的群聊」推进成「能被调度、能被管理、能自己转起来的工作容器」——在意愿打分（自然讨论）之上加一条**确定性发言指派通道**（P7 显式 handoff），再让某位茶客承担协调职责把任务推到目标达成（P8 任务管理），最后让「指派 → 执行 → 复查 → 再指派」的闭环在预算内**自动推进**而无需逐步采纳（P8.3 托管任务会话）。
+
+## 亮点
+
+- **显式 handoff（接力）**：意愿打分之上的确定性指派通道。composer 底栏「指派」按钮弹统一面板——勾 1 位茶客 =「交给他发下一句」（delegate）、勾 2~4 位 = 发起一场平行表态的圆桌（panel，可选指定汇总人）；消息气泡上的「请审…」按钮另派一位茶客审阅该条消息（review）。接力跑完即回等用户输入、不回落打分；顶部「➡️ 下一句」队列条可整体取消。
+- **茶客 propose handoff**：茶客也能在发言里**提议**接力（指派 / 请审 / 圆桌），渲成「采纳 / 忽略」卡片，用户点采纳后才走既有 `handoff_*` inbound——写权限仍永远在用户。
+- **任务管理（skill 形态）**：带 `task-management` skill 的茶客能承担协调职责——拆解任务 Goal、按房间茶客情况分工、检查 Goal 是否达成、未达成时复盘调整。完全跑在 P5~P7 已有原语上，零后端改动。示范管理者角色 Maya 见 `examples/personas/Maya/`。
+- **托管任务会话（MTS）**：任务面板「托管运行」可开启一段有预算上限的托管会话——选一位管理者茶客 + 设预算,授权它在预算内自动「指派 → 执行 → 复查 → 再指派」推进任务,期间无需逐步采纳;composer 上方状态条显示剩余预算,「停止托管」随时收场。
+- **能力花名册**：onboarding 的「在场」行从逗号单行升级为带能力摘要的 bullet 花名册，帮管理者茶客 / 用户挑人分工。摘要三级解析（手写 `[[guest]].summary` → LLM 后台生成缓存 → 无）。
+- **`/tools` `/skills` 茶客能力查询**：只读 slash 查询某位茶客 agent 注册的工具 + 可用 skills + 当前权限模式，结果显示为系统气泡，不进记录。
+- **任务事件改系统气泡**：开 / 关任务 / 加决策 / 挂产物不再合成 user 消息进 transcript，改为渲一条居中系统气泡——不进记录、不触发 AI（代价：task 操作不再「唤醒」房间，需 `@提及` / handoff 显式介入）。
+- **开源协议 Apache License 2.0**：从 MIT 切换到 Apache 2.0（显式专利授权 + 商标条款）。
+
+## 里程碑（按提交序）
+
+- **P7.1 显式 handoff —— delegate 调度**：新建 `chahua/handoff.py`（`HandoffItem` / `HandoffKind` / 内存队列）；`run_pending_handoff` drain loop 与 `_run_ai_chain` 严格分流不互相回落；`_run_handoff_turn` wrapper；server `_inflight_kind` 三态 + 条件性抢占；前端茶客侧栏 ⇨ 按钮 + 队列预览条。
+- **P7.2 显式 handoff —— review（请审）**：`HandoffKind.REVIEW` + `review_message_id`；`extra_blocks` 临时块管线（`<review_target>` 注入 `<speak_instruction>` 之前，onboarding / incremental 两路都接）；消息气泡「请审…」按钮（只挂带 `message_id` 的气泡）。review 与 delegate 调度层完全同构。
+- **P7.3 显式 handoff —— panel（圆桌）**：`HandoffKind.PANEL` + `targets` / `summarizer` 字段；drain loop `kind` 三路分流走三个纯函数（`_handoff_cost` / `_resolve_handoff_winners` / `_build_winner_blocks`）；panel = 一个自描述 item、一个 turn 串行 speak N(+1) 次；`_advance_to_runnable_handoff` 弹死项 helper。
+- **handoff UI 统一**：P7.1 茶客行 ⇨ 按钮与 P7.3 侧栏「圆桌」多选模式合并成 composer 底栏单个「指派」入口——勾选人数定语义（1 人 delegate / 2~4 人 panel）。纯前端改动，inbound 协议 / 五道校验 / drain 调度层全不变。
+- **P7.4 显式 handoff —— 茶客 propose**：新建 `chahua/handoff_tools.py`（`propose_delegate` / `propose_review` / `propose_panel`，不带 `task_` 前缀）；复用 P5 的 `TASK_PROPOSAL` envelope + `proposal_card.js` 卡片机制；`propose_review` 在 propose 时把 `reviewee` 名解析成 `message_id` 并冻结。采纳走既有 `handoff_*` inbound，server handler 零改动。
+- **`/tools` `/skills` 茶客能力 introspection**：共享投影 `TeaGuest.describe_capabilities()`；WebSocket `list_guest_caps` inbound + `GUEST_CAPS_INFO` envelope；CLI REPL 同样接，直调投影无 inbound 往返。
+- **P5.8 任务事件改系统气泡**：五个 task inbound + 茶客自动归集从「合成 user 消息进 transcript + 起 turn」改为只 emit `TASK_*` hint + `TASK_INFO`；删除 `_kick_synthesized_user_message` / `task_event_text.py`；文案唯一来源移到前端 `formatTaskEventNotice`。
+- **P8 任务管理 —— skill 形态 + `task_propose_status`**：`task-management` skill 作 persona-bundled skill 落地（零后端改动），新增 Maya 示范管理者角色；新增第五个 task 工具 `task_propose_status(status, reason)`，采纳按终结态分流（非终结态 → `update_task`、终结态 → `close_task`）。
+- **P8.2 能力花名册**：roster-a 手写 `[[guest]].summary` room.toml 字段（走 P4 配置闭环四点）；roster-b 新建 `chahua/persona_summary.py`——persona 能力摘要 LLM 后台生成 + 中央内容寻址缓存。花名册是装配期不可变快照，只进 onboarding 不进每轮 `<room_update>`。
+- **P8.3 原生自动推进 —— 托管任务会话（MTS）**：`chahua/handoff.py` 加 `ManagedSession` dataclass（瞬态、不落盘、单房间最多 1 个）；`ChahuaTransport.task_proposal_hook` 自动入队管理者的 delegate / panel 提议（拦下 envelope 不渲卡）；MTS 跑在 handoff drain loop 上、每轮 turn 末尾调 `_advance_managed_session_after_turn`；6 个结束 reason；两个 inbound（`managed_session_start` / `stop`）。纯调度层增量，复用 P7 全套承重墙。
+
+## 模块新增（同期）
+
+- `chahua/handoff.py` —— handoff 数据契约 + 内存队列 + `ManagedSession`。
+- `chahua/handoff_tools.py` —— 三个茶客侧 handoff propose 工具。
+- `chahua/persona_summary.py` —— persona 能力摘要 LLM 生成 + 中央内容寻址缓存。
+- `chahua/server_inbound_handoff.py` —— handoff / MTS inbound handler slot（P7 inbound 拆模块时新增第 5 个 handler 类）。
+- `examples/personas/Maya/` —— 示范管理者角色 + bundled `task-management` skill。
+- `app/renderer/assign_popover.js` —— 统一「指派」面板。
+
+## 开源协议
+
+- **MIT → Apache License 2.0**：`LICENSE` 换成 Apache 2.0 全文（`Copyright 2026 Bo Jin`）；`pyproject.toml` 的 `license` 字段改 `Apache-2.0`（SPDX）；`README.md` License 节同步。Apache 2.0 在 MIT 的宽松基础上多了显式专利授权与商标条款。
+
+## Release prep
+
+- 版本号 `0.1.1 → 0.1.2`：`pyproject.toml` / `chahua/__init__.py` / `app/package.json` / `app/package-lock.json` 四处同步。
+- CHANGELOG：`[Unreleased]` rename 为 `## [0.1.2] - 2026-05-21` + 加发布说明链接。
+- 测试套：860 passed in ~52s，零 fail 零 skip。
+
+## 已知未做
+
+- **Windows .exe** 实跑：接缝（platform 分支 / sidecar resolver / stdin EOF graceful shutdown / `build.win` 配置 / `mklink /J` junction 兜底）从 v0.1.0 起一直就位，但还没在 Windows 主机 / CI matrix 端真正跑过 `npm run build:win`。
+- **macOS 签名 / 公证**：.dmg 仍未签名，用户双击仍会 Gatekeeper 红屏；ctrl-click → 打开 走一次即可。脱 Gatekeeper 警告需 Apple Developer ID（$99/年）。
+- **ACP 异构茶客**：仍只支持 agentao 驱动的茶客。接第一个非 agentao 的 ACP 茶客（`transport = "acp"`）是后续大版本。
+- **slash `/manage` / `/panel` / `/propose`**：MTS 与 handoff 首版都不做对应 slash 命令，推后。
+- **MTS 不跨断线 / 重启存活**：`ManagedSession` 是瞬态运行态，断线即结束（`user_cancel`），不做持久化恢复——刻意选择，与 `_handoff_queue` 同语义。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.2.dev0"
+version = "0.1.2"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
v0.1.2 发布准备 —— 任务 1~4（任务 5 git tag 待本 PR 合并后在 main 上打）。

## 改动

- **版本号 `0.1.2.dev0` → `0.1.2`**：`pyproject.toml` / `chahua/__init__.py` / `app/package.json` / `app/package-lock.json` 四处同步
- **CHANGELOG**：`[Unreleased]` rename 为 `## [0.1.2] - 2026-05-21` + 加发布说明链接
- **新增 `docs/releases/v0.1.2.md`**：显式 handoff（P7.1~7.4）/ 任务管理与原生自动推进（P8 / P8.2 / P8.3）/ `/tools`·`/skills` / 任务事件改系统气泡 / Apache 协议切换的发布说明

## 范围

本版相对 v0.1.1 的全部内容（即原 CHANGELOG `[Unreleased]` 段）已完整收录进发布说明。860 测试全过。

## 合并后

- 在 `main` 上打 `v0.1.2` tag
- 发布时跑 `npm run build:python && npm run build:mac` 出 .dmg 并本机冒烟

🤖 Generated with [Claude Code](https://claude.com/claude-code)