### PR TITLE
chahua: electron-builder artifactName 改 ASCII 命名

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -61,7 +61,7 @@
           "arch": ["arm64"]
         }
       ],
-      "artifactName": "茶话室-${version}-mac-${arch}.${ext}",
+      "artifactName": "chahua-${version}-mac-${arch}.${ext}",
       "hardenedRuntime": false,
       "gatekeeperAssess": false,
       "identity": null
@@ -77,7 +77,7 @@
           "arch": ["x64"]
         }
       ],
-      "artifactName": "茶话室-${version}-win-${arch}.${ext}"
+      "artifactName": "chahua-${version}-win-${arch}.${ext}"
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
## 问题

GitHub Release 上传资产时会剥掉文件名里的非 ASCII 字符。`artifactName` 用中文前缀「茶话室-${version}-...」时,产出的 `茶话室-0.1.2-mac-arm64.dmg` 上传后变成 `-0.1.2-mac-arm64.dmg` —— 既不美观,`-` 开头还会被 `gh` CLI 误当 flag 解析(v0.1.2 发布时 `gh release delete-asset` 因此报 `unknown shorthand flag: '0'`,需 `--` 分隔符绕过)。

## 改动

`app/package.json` 的 electron-builder `build` 配置:`mac.artifactName` / `win.artifactName` 从 `茶话室-${version}-...` 改为 `chahua-${version}-...`。

- 与 v0.1.0 / v0.1.1 dist 里既有的 `chahua-<ver>` 命名一致
- `productName`（茶话室）/ `dmg.title`（茶话室 ${version}）**保留中文** —— 那是 App 显示名 / 挂载卷名,非文件名,不受资产名清洗影响

下次 `npm run build:mac` 直接产出 `chahua-<ver>-mac-arm64.dmg`,免去手动重命名重传。

🤖 Generated with [Claude Code](https://claude.com/claude-code)