### PR TITLE
chahua: 开 v0.1.3 开发周期 —— 版本号 0.1.2 → 0.1.3.dev0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.2",
+  "version": "0.1.3-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.2",
+      "version": "0.1.3-dev",
       "dependencies": {
         "dompurify": "^3.4.3",
         "marked": "^18.0.3"

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.2",
+  "version": "0.1.3-dev",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.2"
+version = "0.1.3.dev0"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
v0.1.2 已发布,开下一个开发周期。

版本号 `0.1.2` → `0.1.3.dev0`(python)/ `0.1.3-dev`(npm),四处同步:

- `pyproject.toml`
- `chahua/__init__.py`
- `app/package.json`
- `app/package-lock.json`(顶层 + `packages.""` 两处)

发布 v0.1.3 时去 dev 后缀。CHANGELOG `## [Unreleased]` 段已就位,无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)