### PR TITLE
chahua: 重构 renderer.js —— 拆成 8 个单一职责模块

### DIFF
--- a/app/renderer/commands.js
+++ b/app/renderer/commands.js
@@ -1,0 +1,121 @@
+"use strict";
+
+// 斜杠命令解析。从 renderer.js 的 composer submit handler 抽出（renderer 重构）。
+//
+// tryHandle(text) 命中某条命令即执行并返回 true（调用方据此 return、不再走普通发送
+// 路径）；非命令返回 false。所有命令都是本地 UI 行为或单条 inbound，不进 transcript，
+// 刷新 / 切房后消失。调用前 composer submit handler 已确认 connected。
+
+import { Inbound } from "./events.js";
+
+// ``/help`` 输出文案 —— 用 markdown 渲，居中系统气泡承载。**Web 与 CLI 两面 help 各
+// 自维护本面支持的命令**：CLI 端的 ``_HELP_LINES`` 含 ``/info`` / ``/quit``（REPL 才
+// 有意义），Web 端含 ``/task``（CLI 走 ``@<名字>`` 路径不开任务）。加 / 改命令时
+// 改本面的那份即可，不必试图 cross-runtime 同步。
+const HELP_TEXT = [
+  "**chahua 系统命令**",
+  "",
+  "- `/help` 或 `/?` —— 显示本帮助",
+  "- `/task <标题>` —— 新建任务（已有 active 时服务端会拒）",
+  "- `/clear` 或 `/new` —— 清空整间房间聊天（重置 transcript / 摘要 / 茶客会话窗口）",
+  "- `/clear task` —— 清空当前任务的全部产物（仅删 `artifacts/`，任务本身保留）",
+  "- `/tools <茶客名>` —— 查看某位茶客 agent 注册的工具",
+  "- `/skills <茶客名>` —— 查看某位茶客可用的 skills",
+  "",
+  "_本帮助是本地提示，不进 transcript；刷新 / 切房后消失。_",
+].join("\n");
+
+export function createCommands({
+  isConnected,
+  send,
+  setStatus,
+  appendBubble,
+  taskState,
+  upload,
+  clearRoom,
+  clearInput,
+}) {
+  function tryHandle(text) {
+    // /help（或 /?）—— 在聊天区里以系统气泡显示可用斜杠命令清单。本地 UI 行为，不
+    // 走 server 帧、不进 transcript；刷新 / 切房 / clear 都会消失。
+    if (text === "/help" || text === "/?") {
+      appendBubble({ kind: "system", text: HELP_TEXT });
+      clearInput();
+      return true;
+    }
+    // /tools <茶客名> / /skills <茶客名> —— 查某位茶客 agent 的 tools / 可用 skills。
+    // 两者走同一只读 inbound list_guest_caps；view 随帧发出、回包原样带回，前端按它
+    // 裁剪显示哪段（不靠全局态，多查询并发不串台）。本地查询，不进 transcript。
+    const isTools = text === "/tools" || text.startsWith("/tools ");
+    const isSkills = text === "/skills" || text.startsWith("/skills ");
+    if (isTools || isSkills) {
+      const cmd = isTools ? "/tools" : "/skills";
+      const guest = text.slice(cmd.length).trim();
+      if (!guest) {
+        setStatus("error", `${cmd} 后面要跟茶客名`);
+        return true;
+      }
+      if (!isConnected()) {
+        setStatus("error", "未连接服务端");
+        return true;
+      }
+      send({
+        type: Inbound.LIST_GUEST_CAPS,
+        guest,
+        view: isTools ? "tools" : "skills",
+      });
+      clearInput();
+      return true;
+    }
+    // 斜杠命令 —— /task <title> 走 open_task inbound 而非 user_message。已有任务等
+    // server 端拒绝（NOTICE error），前端不重复判定，让两条路径决断口径完全同源。
+    if (text.startsWith("/task ") || text === "/task") {
+      const title = text.slice("/task".length).trim();
+      if (!title) {
+        setStatus("error", "/task 后面要跟任务标题");
+        return true;
+      }
+      if (upload.hasPending()) {
+        setStatus("error", "新建任务前先 × 掉待发文件 —— 任务不接附件");
+        return true;
+      }
+      send({ type: Inbound.OPEN_TASK, title, goal: "", owner: null });
+      setStatus("", `新建任务「${title}」…`);
+      clearInput();
+      return true;
+    }
+    // /clear task：清空当前 active 任务的全部产物（仅删 artifacts/，任务本身保留）。
+    // 必须排在 /clear / /new 之前 —— 否则 startsWith 边界让 "/clear task" 被前缀吞掉。
+    if (text === "/clear task" || text === "/clear-task") {
+      const active = taskState.getActiveTask();
+      if (!active) {
+        setStatus("error", "/clear task 需要先选中一个任务");
+        return true;
+      }
+      const count = Array.isArray(active.artifacts) ? active.artifacts.length : 0;
+      if (count === 0) {
+        setStatus("", `任务「${active.title}」没有产物`);
+        clearInput();
+        return true;
+      }
+      if (!window.confirm(
+        `确定清空任务「${active.title}」的全部产物（${count} 个文件）？\n任务本身（决策 / 状态 / 摘要）保留，仅删 artifacts/ 下的文件。`,
+      )) return true;
+      send({ type: Inbound.CLEAR_TASK_ARTIFACTS, task_id: active.id });
+      setStatus("", `清空任务「${active.title}」的产物…`);
+      clearInput();
+      return true;
+    }
+    // /clear 与 /new：键盘快捷的"清空聊天"，与房间菜单同入口共用 confirm —— 滑指误打
+    // /task 边界（如想 /task 打成 /clear）有 confirm 兜底；clearRoom 内部不连接
+    // 时 noop，所以此处不再判 connected。
+    if (text === "/clear" || text === "/new") {
+      clearInput();
+      clearRoom();
+      return true;
+    }
+    return false;
+  }
+
+  return { tryHandle };
+}

--- a/app/renderer/connection.js
+++ b/app/renderer/connection.js
@@ -1,0 +1,84 @@
+"use strict";
+
+// WebSocket 连接 + 重连退避。从 renderer.js 抽出（renderer 重构）。
+//
+// 持有 socket 与 connected 标志；renderer 经 send / isConnected 读写连接，经
+// onConnecting / onMessage / onClose 三个回调接生命周期。重连决策（退避梯度 /
+// NO_RECONNECT_CODES）整个封在模块内。
+
+// 退避梯度（ms）。超过梯度长度后稳定在最后一档，永远尝试 —— 桌面 App 无云端账号，
+// 用户没退就接着连；不退指数到分钟级避免长时间断线后用户等不及。
+const RECONNECT_BACKOFF_MS = [1000, 2000, 5000, 10000];
+
+// 这些 close code 表示对端"主动且无意挽回"，不自动重连：
+//   1000 normal closure（双方约定关）
+//   1001 going away（页面切走 / 后端 quit）
+//   1008 policy violation（server.py 拒第二客户端 —— 重连只会再次被拒）
+const NO_RECONNECT_CODES = new Set([1000, 1001, 1008]);
+
+export function createConnection({
+  wsUrl,
+  setStatus,
+  onConnecting,
+  onMessage,
+  onClose,
+}) {
+  let ws = null;
+  let connected = false;
+  let reconnectAttempt = 0;
+
+  function reconnectDelayMs() {
+    const i = Math.min(reconnectAttempt, RECONNECT_BACKOFF_MS.length - 1);
+    return RECONNECT_BACKOFF_MS[i];
+  }
+
+  function scheduleReconnect() {
+    const delay = reconnectDelayMs();
+    reconnectAttempt += 1;
+    setStatus("error", `连接断开 —— 第 ${reconnectAttempt} 次重试，${delay / 1000}s 后…`);
+    // P3.3 加"立即重连 / 停止重连"按钮时再持有 timer 引用便于 clearTimeout。
+    setTimeout(connect, delay);
+  }
+
+  function connect() {
+    // 重试中文案 vs 首次连接区分开 —— 首次空白，重试带次数。
+    const tag = reconnectAttempt > 0 ? `（第 ${reconnectAttempt} 次重试）` : "";
+    setStatus("", `连接中… ${wsUrl}${tag}`);
+    onConnecting();
+    ws = new WebSocket(wsUrl);
+    ws.addEventListener("open", () => {
+      connected = true;
+      reconnectAttempt = 0;
+      setStatus("ok", `已连接 ${wsUrl}（等 room_info）`);
+      // composer 解锁延迟到 renderSidebar —— 让 user echo 名字、@ 候选都准备就绪
+      // 后再让用户能输入；避免 "我" → 真名跳变 + @ 候选空白窗口。
+    });
+    ws.addEventListener("message", (ev) => {
+      try {
+        onMessage(JSON.parse(ev.data));
+      } catch (e) {
+        console.error("envelope parse failed:", e, ev.data);
+      }
+    });
+    ws.addEventListener("close", (ev) => {
+      connected = false;
+      // renderer 侧断线清理（输入禁用 / in-flight 收尾 / handoff / MTS / 上传 / 按钮）。
+      onClose(ev.code, ev.reason);
+      if (NO_RECONNECT_CODES.has(ev.code)) {
+        setStatus("error", `连接断开 (${ev.code} ${ev.reason || ""})`);
+        return;
+      }
+      scheduleReconnect();
+    });
+    ws.addEventListener("error", (ev) => {
+      console.error("ws error", ev);
+    });
+  }
+
+  return {
+    start: connect,
+    // 闭包读最新 ws —— 重连时 ws 被重赋值，每次调用读到当前绑定。
+    send: (payload) => ws.send(JSON.stringify(payload)),
+    isConnected: () => connected,
+  };
+}

--- a/app/renderer/envelope_router.js
+++ b/app/renderer/envelope_router.js
@@ -1,0 +1,268 @@
+"use strict";
+
+// envelope 分派 —— ws 下行每帧一条 envelope，按 type 分发到各 feature 模块。
+// 从 renderer.js 抽出（renderer 重构）。
+//
+// envelope 消费完整路径：
+//   room_info     → ws 连上首帧：装 sidebar（房间名 / topic / 茶客 + permission）
+//   room_history  → 历史回放 + 调试索引
+//   turn_start    → sidebar 各茶客名右侧显示本轮打分小数字
+//   message_*     → 流式气泡 起 / 增量 / 封口
+//   turn_end      → 清打分 + 收「停止」按钮
+//   task_* / handoff_* / managed_session_* → 各 feature 模块
+//   guest_thinking / tool_*  → 静默
+//
+// foregroundRoomId（当前前台房 envelope room_id）全封进模块：P9 后台房间里程碑据它
+// 分流 —— room_id 与前台不同且属白名单类型 → 只刷房间列表徽标，不污染前台。
+
+import {
+  EventType,
+  Status,
+  NoticeLevel,
+  BACKGROUND_MILESTONE_TYPES,
+  formatTaskEventNotice,
+  formatManagedSessionNotice,
+} from "./events.js";
+import * as taskState from "./task_state.js";
+import * as handoffState from "./handoff_state.js";
+
+// GUEST_CAPS_INFO envelope → system 气泡文案。view 决定列 tools 还是 skills 段
+// （permission / guest 两段共用）。description 取首行 + 截断，避免长描述刷屏。
+function formatGuestCaps(data, view) {
+  const guest = data.guest || "?";
+  const brief = (s) => (s || "").split("\n")[0].slice(0, 100);
+  if (view === "skills") {
+    const skills = Array.isArray(data.skills) ? data.skills : [];
+    const lines = [`**${guest}** 可用 skills（${skills.length}）`];
+    if (!skills.length) lines.push("_（无）_");
+    for (const s of skills) {
+      lines.push(`- \`${s.name}\`${s.description ? ` —— ${brief(s.description)}` : ""}`);
+    }
+    return lines.join("\n");
+  }
+  const tools = Array.isArray(data.tools) ? data.tools : [];
+  const lines = [`**${guest}** 注册的 tools（${tools.length}，权限模式：${data.permission || "?"}）`];
+  for (const t of tools) {
+    const ro = t.is_read_only ? "read-only" : "write";
+    lines.push(`- \`${t.name}\` (${ro})${t.description ? ` —— ${brief(t.description)}` : ""}`);
+  }
+  return lines.join("\n");
+}
+
+// Blob → <a download> 触发浏览器原生下载。CSP 已允许 'self'，blob: URL 在 Chromium
+// 里也通过 default-src 'self'。
+function triggerDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function createEnvelopeRouter({
+  roomList,
+  debugPanel,
+  renderSidebar,
+  renderHistory,
+  applyScores,
+  turnState,
+  proposalCard,
+  startStreamingMessage,
+  appendDelta,
+  endStreamingMessage,
+  appendBubble,
+  setStatus,
+  upload,
+  taskPanel,
+  managedSession,
+}) {
+  // P9：当前前台房间在 envelope 里的 room_id（= room.name，见 chahua/events.py）。
+  // 从 room_info envelope 顶层 room_id 捕获。
+  let foregroundRoomId = null;
+
+  function handleEnvelope(env) {
+    // P9：后台房间里程碑分流 —— envelope.room_id 与前台不同、且属后台白名单类型
+    // （turn_* / message_end / task_info / task_artifact_added / managed_session_* /
+    // room_background_finished）→ 当作后台房间里程碑，只更新房间列表「进行中」徽标，
+    // 不让它污染前台聊天 / 任务面板 / 调试抽屉。控制面事件（room_info / room_history
+    // / notice 等）不在白名单内 —— 切房时新房 room_info 的 room_id 虽 ≠ 旧前台，仍
+    // 照常落到下面 switch 并由 ROOM_INFO 分支刷新 foregroundRoomId。
+    if (
+      foregroundRoomId !== null &&
+      env.room_id &&
+      env.room_id !== foregroundRoomId &&
+      BACKGROUND_MILESTONE_TYPES.has(env.type)
+    ) {
+      roomList.onBackgroundMilestone(env);
+      return;
+    }
+    // 调试抽屉旁路消费 —— 模块内部按 env.type dispatch；ROOM_INFO 的 reset 在
+    // renderSidebar 里调（与 inFlight / proposalCard 同步清）。
+    debugPanel.onEnvelope(env);
+    switch (env.type) {
+      case EventType.ROOM_INFO:
+        // 前台房间在 envelope 里的 room_id（= room.name）—— 后台分流的判定基准。
+        foregroundRoomId = env.room_id ?? null;
+        renderSidebar(env.data ?? {});
+        return;
+      case EventType.ROOM_HISTORY:
+        renderHistory(env.data?.messages ?? []);
+        // P6.3.A：``turns_index`` 倒序投影注入调试抽屉的历史索引（``debug.enabled=False``
+        // 时整字段缺省 → applyTurnsIndex 不入 array，索引区维持空）。
+        debugPanel.applyTurnsIndex(env.data?.turns_index ?? null);
+        return;
+      case EventType.TURN_START: {
+        const scores = env.data?.scores ?? [];
+        console.debug("[turn_start]", scores);
+        applyScores(scores);
+        turnState.set(env.turn_id);
+        return;
+      }
+      case EventType.MESSAGE_START:
+        startStreamingMessage(env);
+        return;
+      case EventType.MESSAGE_DELTA:
+        appendDelta(env);
+        return;
+      case EventType.MESSAGE_END:
+        endStreamingMessage(env);
+        return;
+      case EventType.TURN_END: {
+        applyScores([]);
+        // AI 链终态判定：status != ok（cancelled）或 next==='user'（用户该说话了）→ 收
+        // 「停止」按钮。next==='ai' 时维持，下一个 turn_start 立刻刷新 turn 状态。
+        const next = env.data?.next;
+        if (env.status !== Status.OK || next === "user") {
+          turnState.clear();
+          // AI 链收尾、无 in-flight turn —— 放开被 gate 的 handoff 采纳按钮（此刻采纳
+          // 不会抢占截断任何 turn）。next==='ai' 时链未结束，不放。
+          proposalCard.onTurnIdle();
+        }
+        return;
+      }
+      case EventType.NOTICE: {
+        // 服务端 mutator 的一次性反馈 —— 目前 persona 导入用。错误强提示 alert，
+        // 让用户立刻看到原因；info 走 status bar 不打断流。
+        const level = env.data?.level || NoticeLevel.INFO;
+        const text = env.data?.text || "";
+        if (!text) return;
+        if (level === NoticeLevel.ERROR) {
+          window.alert(text);
+          setStatus("error", text);
+        } else {
+          setStatus("ok", text);
+        }
+        return;
+      }
+      case EventType.FILE_UPLOADED:
+        upload.onServerEcho(env.data ?? {});
+        return;
+      // 任务房间（docs/P5-任务房间.md §4.2）。TASK_INFO 是权威快照 → 全量覆盖 taskState
+      // 让面板重渲；其它 4 个是 hint → 在对应 DOM 上闪一下，权威 state 等紧跟而至的
+      // TASK_INFO 推进。
+      case EventType.TASK_INFO:
+        taskState.setSnapshot(env.data ?? {});
+        return;
+      // P5.8：task hint 既闪面板增量项、又在聊天区追一条居中系统气泡（task event
+      // 不再合成 user 消息进 transcript）。气泡是瞬时 UI 通知，刷新 / 切房即清。
+      case EventType.TASK_OPEN:
+      case EventType.TASK_DECISION_ADDED:
+      case EventType.TASK_ARTIFACT_ADDED:
+      case EventType.TASK_CLOSE: {
+        taskPanel.flashHint(env.type, env.data ?? {});
+        const text = formatTaskEventNotice(env.type, env.data ?? {});
+        if (text) appendBubble({ kind: "system", text });
+        return;
+      }
+      case EventType.TASK_ARTIFACTS_CLEARED: {
+        // 不调 flashHint —— 清空动作没有可高亮的"新增项"，状态推进全靠紧随的
+        // TASK_INFO；本事件唯一价值就是系统气泡。
+        const text = formatTaskEventNotice(env.type, env.data ?? {});
+        if (text) appendBubble({ kind: "system", text });
+        return;
+      }
+      // TASK_UPDATE 不显示气泡 —— 避免用户编辑标题时聊天流被刷。
+      case EventType.TASK_UPDATE:
+        taskPanel.flashHint(env.type, env.data ?? {});
+        return;
+      case EventType.TASK_PROPOSAL:
+        proposalCard.onEnvelope(env);
+        return;
+      // P7.1 显式 handoff（docs/P7 §3.3）。三个事件维护本地队列预览；权威状态就是
+      // 队列本身——服务端不落盘，刷新 / 切房在 renderSidebar 里 reset。
+      case EventType.HANDOFF_ENQUEUED:
+        handoffState.applyEnqueued(env.data?.queue ?? []);
+        return;
+      case EventType.HANDOFF_CONSUMED:
+        handoffState.applyConsumed(env.data?.item ?? null);
+        return;
+      case EventType.HANDOFF_CLEARED:
+        handoffState.applyCleared();
+        return;
+      // P8.3 托管会话（docs/P8.3 §3.4）。三个 hint 事件维护状态条；ended 追系统气泡。
+      case EventType.MANAGED_SESSION_STARTED:
+        managedSession.onStarted(env.data ?? {});
+        return;
+      case EventType.MANAGED_SESSION_ADVANCED:
+        managedSession.onAdvanced(env.data ?? {});
+        return;
+      case EventType.MANAGED_SESSION_ENDED: {
+        const reason = env.data?.reason;
+        managedSession.onEnded(env.data ?? {});
+        appendBubble({ kind: "system", text: formatManagedSessionNotice(reason) });
+        return;
+      }
+      case EventType.GUEST_CAPS_INFO: {
+        // view 由请求方经 envelope 回声带回 —— 多条 /tools / /skills 并发时各响应
+        // 自带"查的是哪段"，不靠全局态对号入座。
+        const data = env.data ?? {};
+        appendBubble({ kind: "system", text: formatGuestCaps(data, data.view) });
+        return;
+      }
+      case EventType.ROOM_EXPORT: {
+        const markdown = env.data?.markdown;
+        const filename = env.data?.filename || "chahua-export.md";
+        if (typeof markdown !== "string") return;
+        triggerDownload(
+          new Blob([markdown], { type: "text/markdown;charset=utf-8" }),
+          filename,
+        );
+        setStatus("ok", `已导出 ${filename}`);
+        return;
+      }
+      case EventType.FILE_DOWNLOAD: {
+        // 失败路径：NOTICE 已弹过 alert，envelope 仅含 {rel, error}，跳过 Blob 流程。
+        const d = env.data || {};
+        if (d.error) return;
+        const b64 = d.content_b64;
+        const name = d.name || "download";
+        if (typeof b64 !== "string") return;
+        // base64 → Uint8Array → Blob。atob 一次性解码 ~200MB 在 Chromium 还稳；超大
+        // base64 字符串在 ws 入站早就被 _DOWNLOAD_MAX_BYTES 拦了。
+        let bin;
+        try {
+          bin = atob(b64);
+        } catch (e) {
+          setStatus("error", `下载「${name}」失败：base64 解码出错`);
+          return;
+        }
+        const bytes = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
+        // 走 application/octet-stream 让浏览器把它当下载而非 inline preview。具体 mime
+        // 类型由扩展名决定，留给操作系统打开时自己识别。
+        triggerDownload(
+          new Blob([bytes], { type: "application/octet-stream" }),
+          name,
+        );
+        setStatus("ok", `已下载「${name}」`);
+        return;
+      }
+      // guest_thinking / tool_* 暂时静默。
+    }
+  }
+
+  return { handleEnvelope };
+}

--- a/app/renderer/message_filter.js
+++ b/app/renderer/message_filter.js
@@ -1,0 +1,136 @@
+"use strict";
+
+// 消息上的任务 chip + filter 视图（P5.2.10）。从 renderer.js 抽出（renderer 重构）。
+//
+// 非 active 任务的消息气泡挂一个可点的任务 chip；点 chip 进 filter 视图（只显示该
+// 任务的消息，其余 .filtered-out 隐起来）+ 顶部出现一条"返回全部"横幅。filter 状态
+// （_filterTaskId / banner DOM）是本模块私有 —— 外部只通过 afterAppendMessage /
+// exitFilter / onTaskStateChange 三个出口交互。
+
+import { formatTaskLabel, TASK_UNTITLED } from "./events.js";
+
+export function createMessageFilter({ messagesEl, taskState }) {
+  let _filterTaskId = null;
+  let _filterBannerEl = null;
+
+  function getLiTaskId(li) {
+    return li.dataset.taskId || null;
+  }
+
+  function refreshMessageTaskChip(li) {
+    const taskId = getLiTaskId(li);
+    let chip = li.querySelector(".message-task-chip");
+    const removeChip = () => { if (chip) { chip.remove(); chip = null; } };
+    if (!taskId) {
+      removeChip();
+      return;
+    }
+    const activeId = taskState.getState().activeTaskId;
+    // active 任务的消息不挂 chip —— 默认 chat 主流就是 active，挂了反而吵。
+    if (taskId === activeId) {
+      removeChip();
+      return;
+    }
+    // task 还没加载（room_history 先于 task_info）/ 被删了 —— 不挂；下次 subscriber 补。
+    const task = taskState.getTaskById(taskId);
+    if (!task) {
+      removeChip();
+      return;
+    }
+    const text = formatTaskLabel(task);
+    if (chip) {
+      if (chip.textContent !== text) chip.textContent = text;
+      return;
+    }
+    chip = document.createElement("button");
+    chip.type = "button";
+    chip.className = "message-task-chip";
+    chip.textContent = text;
+    chip.title = `进入任务「${task.title || TASK_UNTITLED}」的 filter 视图`;
+    chip.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      enterMessageFilter(taskId);
+    });
+    const bubble = li.querySelector(".bubble");
+    if (bubble) bubble.appendChild(chip);
+  }
+
+  function refreshAllMessageTaskChips() {
+    for (const li of messagesEl.querySelectorAll("li[data-task-id]")) {
+      refreshMessageTaskChip(li);
+    }
+  }
+
+  function applyMessageFilterTo(li) {
+    if (_filterTaskId === null) {
+      li.classList.remove("filtered-out");
+      return;
+    }
+    li.classList.toggle("filtered-out", getLiTaskId(li) !== _filterTaskId);
+  }
+
+  function applyMessageFilterAll() {
+    for (const li of messagesEl.querySelectorAll("li")) applyMessageFilterTo(li);
+  }
+
+  // 三处 append 调用站（appendBubble / startStreamingMessage / endStreamingMessage 的
+  // 无 start 分支）的尾部都做一样的事 —— 刷 chip + 应用 filter。单出口，将来加 third
+  // concern（搜索高亮 / 已读标记等）也只动这里。
+  function afterAppendMessage(li) {
+    refreshMessageTaskChip(li);
+    applyMessageFilterTo(li);
+  }
+
+  function enterMessageFilter(taskId) {
+    _filterTaskId = taskId;
+    ensureFilterBanner();
+    updateFilterBannerText();
+    _filterBannerEl.hidden = false;
+    applyMessageFilterAll();
+  }
+
+  function exitMessageFilter() {
+    if (_filterTaskId === null) return;
+    _filterTaskId = null;
+    if (_filterBannerEl) _filterBannerEl.hidden = true;
+    applyMessageFilterAll();
+  }
+
+  function ensureFilterBanner() {
+    if (_filterBannerEl) return;
+    _filterBannerEl = document.createElement("div");
+    _filterBannerEl.className = "message-filter-banner";
+    _filterBannerEl.hidden = true;
+    const text = document.createElement("span");
+    text.className = "message-filter-banner-text";
+    _filterBannerEl.appendChild(text);
+    const exit = document.createElement("button");
+    exit.type = "button";
+    exit.className = "message-filter-banner-exit";
+    exit.textContent = "返回全部";
+    exit.addEventListener("click", exitMessageFilter);
+    _filterBannerEl.appendChild(exit);
+    // 插到 messagesEl 紧前 —— flex 容器 #main 里同级 sibling，挡不到聊天区域滚动。
+    messagesEl.parentNode.insertBefore(_filterBannerEl, messagesEl);
+  }
+
+  function updateFilterBannerText() {
+    if (!_filterBannerEl || _filterTaskId === null) return;
+    const task = taskState.getTaskById(_filterTaskId);
+    const title = task ? task.title || TASK_UNTITLED : _filterTaskId;
+    _filterBannerEl.querySelector(".message-filter-banner-text").textContent =
+      `仅显示任务「${title}」的消息 —— 其余隐起来`;
+  }
+
+  return {
+    // chat_stream 三处 append 的尾部钩子。
+    afterAppendMessage,
+    // 切房 / 重连 / 清空 → filter 视图无意义，强 exit。
+    exitFilter: exitMessageFilter,
+    // taskState 变（改名 / 切 active / 关任务）→ 刷 chip 文案 + filter banner 文案。
+    onTaskStateChange() {
+      refreshAllMessageTaskChips();
+      if (_filterTaskId !== null) updateFilterBannerText();
+    },
+  };
+}

--- a/app/renderer/modals.js
+++ b/app/renderer/modals.js
@@ -1,0 +1,169 @@
+"use strict";
+
+// 添加茶客 / 新建房间 / 新建任务 / 导入 persona 四个 modal 的装配。从 renderer.js
+// 抽出（renderer 重构）。
+//
+// 模块自取所需 DOM 节点（这些节点只此处用），renderer 经少量回调注入连接 / 发送 /
+// 名单。openModal / closeModal 由 renderer 传入（decision_support 等也共用同一对）。
+// 全部 modal 的「点 backdrop / × / ESC 关闭」通用兜底也在这里一并挂。
+
+import { Inbound, DEFAULT_PERMISSION, buildOwnerOptionData } from "./events.js";
+import { renderPersonaPicker, createPersonaImport } from "./persona.js";
+
+export function wireModals({
+  isConnected,
+  send,
+  setStatus,
+  getGuests,
+  getPersonas,
+  pickFolder,
+  openModal,
+  closeModal,
+}) {
+  const $ = (id) => document.getElementById(id);
+
+  // ── 添加茶客 ──────────────────────────────────────────────────────
+  const addGuestModal = $("add-guest-modal");
+  const addGuestListEl = $("add-guest-list");
+  $("add-guest").addEventListener("click", () => {
+    if (!isConnected()) return;
+    const inRoom = new Set(getGuests().map((g) => g.name));
+    renderPersonaPicker(addGuestListEl, {
+      personas: getPersonas(),
+      multi: false,
+      excludeNames: inRoom,
+      onPick: (p) => {
+        send({
+          type: Inbound.ADD_GUEST,
+          persona: p.persona,
+          name: p.name,
+          permission: DEFAULT_PERMISSION,
+        });
+        setStatus("", `添加茶客 ${p.name}…`);
+        closeModal(addGuestModal);
+      },
+    });
+    openModal(addGuestModal);
+  });
+
+  // ── 新建房间 ──────────────────────────────────────────────────────
+  const addRoomModal = $("add-room-modal");
+  const newRoomNameEl = $("new-room-name");
+  const newRoomTopicEl = $("new-room-topic");
+  const newRoomRulesEl = $("new-room-rules");
+  const newRoomGuestsEl = $("new-room-guests");
+  $("add-room").addEventListener("click", () => {
+    if (!isConnected()) return;
+    newRoomNameEl.value = "";
+    newRoomTopicEl.value = "";
+    newRoomRulesEl.value = "";
+    renderPersonaPicker(newRoomGuestsEl, {
+      personas: getPersonas(),
+      multi: true,
+      excludeNames: null,
+    });
+    openModal(addRoomModal);
+    newRoomNameEl.focus();
+  });
+  $("new-room-submit").addEventListener("click", () => {
+    if (!isConnected()) return;
+    const name = newRoomNameEl.value.trim();
+    if (!name) {
+      newRoomNameEl.focus();
+      return;
+    }
+    const selected = Array.from(newRoomGuestsEl.querySelectorAll("li.persona-item.selected"));
+    if (selected.length === 0) {
+      window.alert("至少选 1 位茶客");
+      return;
+    }
+    const guestsPayload = selected.map((li) => ({
+      persona: li.dataset.persona,
+      name: li.dataset.name,
+      permission: DEFAULT_PERMISSION,
+    }));
+    // room_id 用 name 直接当目录名 —— server 端 normalize_room_id 会再洗一遍非法字符；
+    // 暴露独立 id 字段会增加 UI 复杂度（用户难以理解 id vs name 的区别）。
+    send({
+      type: Inbound.CREATE_ROOM,
+      room_id: name,
+      name,
+      topic: newRoomTopicEl.value.trim(),
+      rules: newRoomRulesEl.value.trim(),
+      guests: guestsPayload,
+    });
+    setStatus("", `新建房间 ${name}…`);
+    closeModal(addRoomModal);
+  });
+
+  // ── 导入 persona ──────────────────────────────────────────────────
+  createPersonaImport({
+    modal: $("import-persona-modal"),
+    folderPathEl: $("import-folder-path"),
+    folderPickBtn: $("import-folder-pick"),
+    githubUrlEl: $("import-github-url"),
+    submitBtn: $("import-persona-submit"),
+    importBtn: $("import-persona"),
+    isConnected,
+    send,
+    setStatus,
+    pickFolder,
+  });
+
+  // ── 新建任务 ──────────────────────────────────────────────────────
+  const newTaskModal = $("new-task-modal");
+  const newTaskTitleEl = $("new-task-title");
+  const newTaskGoalEl = $("new-task-goal");
+  const newTaskOwnerEl = $("new-task-owner");
+  const taskPanelNewBtn = $("task-panel-new");
+  taskPanelNewBtn.addEventListener("click", () => {
+    if (!isConnected() || taskPanelNewBtn.disabled) return;
+    newTaskTitleEl.value = "";
+    newTaskGoalEl.value = "";
+    // owner 选项与任务卡 owner 下拉同源 —— "" 表示全员，submit 时再 normalize 回 null。
+    newTaskOwnerEl.replaceChildren();
+    for (const data of buildOwnerOptionData(getGuests().map((g) => g.name))) {
+      const opt = document.createElement("option");
+      opt.value = data.value;
+      opt.textContent = data.label;
+      newTaskOwnerEl.appendChild(opt);
+    }
+    newTaskOwnerEl.value = "";
+    openModal(newTaskModal);
+    newTaskTitleEl.focus();
+  });
+  $("new-task-submit").addEventListener("click", () => {
+    if (!isConnected()) return;
+    const title = newTaskTitleEl.value.trim();
+    if (!title) {
+      newTaskTitleEl.focus();
+      return;
+    }
+    const ownerRaw = newTaskOwnerEl.value;
+    send({
+      type: Inbound.OPEN_TASK,
+      title,
+      goal: newTaskGoalEl.value,
+      owner: ownerRaw === "" ? null : ownerRaw,
+    });
+    setStatus("", `新建任务「${title}」…`);
+    closeModal(newTaskModal);
+  });
+
+  // ── 通用关闭：点 backdrop（modal-backdrop 自身、不是内部 .modal）/ × 按钮 / ESC ──
+  const allModals = [
+    addGuestModal, addRoomModal, $("edit-user-modal"), $("import-persona-modal"),
+    $("edit-room-toml-modal"), $("edit-guest-modal"), $("edit-room-modal"),
+    newTaskModal, $("mark-decision-modal"),
+  ];
+  for (const modal of allModals) {
+    modal.addEventListener("click", (ev) => {
+      if (ev.target === modal) closeModal(modal);
+      if (ev.target.matches("[data-close]")) closeModal(modal);
+    });
+  }
+  document.addEventListener("keydown", (ev) => {
+    if (ev.key !== "Escape") return;
+    for (const m of allModals) if (!m.hidden) closeModal(m);
+  });
+}

--- a/app/renderer/renderer.js
+++ b/app/renderer/renderer.js
@@ -59,6 +59,7 @@ import { createComposerTaskChip } from "./composer_task_chip.js";
 import { createChatStream } from "./chat_stream.js";
 import { createMessageFilter } from "./message_filter.js";
 import { createCommands } from "./commands.js";
+import { createConnection } from "./connection.js";
 
 const statusEl = document.getElementById("status");
 const messagesEl = document.getElementById("messages");
@@ -131,13 +132,18 @@ if (!wsUrl) {
   throw new Error("missing wsUrl");
 }
 
-let ws = null;
-let connected = false;
-
-// 闭包读最新 ws —— 重连时 ws 变量会被重赋值，闭包每次调用读到当前绑定。所有
-// feature module（upload / persona / settings）共享同一份 ref，留单点未来加
-// readyState 守卫。
-const send = (payload) => ws.send(JSON.stringify(payload));
+// WebSocket 连接 + 重连退避封在 ./connection.js —— renderer 经 send / isConnected
+// 读写连接、经 onConnecting / onMessage / onClose 回调接生命周期。回调引用的
+// handleEnvelope / handleDisconnect / setInputEnabled 都是 hoisted 函数声明，故可在
+// 此处提前装配（feature module 工厂在下文要拿 send，必须早于它们就绪）。
+const connection = createConnection({
+  wsUrl,
+  setStatus,
+  onConnecting: () => setInputEnabled(false),
+  onMessage: handleEnvelope,
+  onClose: handleDisconnect,
+});
+const send = connection.send;
 
 // chat-stream（气泡 / 流式 / 历史回放）见 ./chat_stream.js；在途消息 Map 封装在
 // 该模块内，外部只通过 ``closeInFlightOnDisconnect`` 一键清。
@@ -213,7 +219,7 @@ function setInputEnabled(enabled) {
 
 // "+ 新任务" 只受 connected 制约（多任务允许任意时刻新建）。
 function updateNewTaskBtn() {
-  taskPanelNewBtn.disabled = !connected;
+  taskPanelNewBtn.disabled = !connection.isConnected();
   taskPanelNewBtn.title = "新建任务";
 }
 
@@ -294,7 +300,7 @@ function closeAssignPopover() {
   assignPopover?.close();
 }
 function openAssignPopover() {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   closeActionPopover();
   assignPopover?.show(assignHandoffBtn);
 }
@@ -303,7 +309,7 @@ function openAssignPopover() {
 // 每位茶客一项（含被审消息作者自己——自审合法、不屏蔽），选中即发 handoff_review。
 // anchor 是请审按钮本身；message_id 由 chat_stream 经 attachReviewButton 透传上来。
 function requestReview(messageId, anchorBtn) {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   if (guests.length === 0) {
     setStatus("error", "房间里没有茶客 —— 无法请审");
     return;
@@ -312,7 +318,7 @@ function requestReview(messageId, anchorBtn) {
     label: g.name,
     onClick: () => {
       // 菜单是异步的——用户从弹出菜单里选茶客时连接可能已断，落点再查一次。
-      if (!connected) return;
+      if (!connection.isConnected()) return;
       send({ type: Inbound.HANDOFF_REVIEW, target: g.name, message_id: messageId });
       setStatus("", `已请「${g.name}」审阅这条发言`);
     },
@@ -375,7 +381,7 @@ function renderGuestRowNormal(li, g, lastGuestLock) {
   node.title = `点击设置「${g.name}」的权限（当前 ${g.permission || DEFAULT_PERMISSION}）`;
   node.addEventListener("click", (ev) => {
     ev.stopPropagation();
-    if (!connected) return;
+    if (!connection.isConnected()) return;
     showPermissionPopover(node, g);
   });
   li.appendChild(node);
@@ -384,7 +390,7 @@ function renderGuestRowNormal(li, g, lastGuestLock) {
   nameBadge.title = `点击设置「${g.name}」的权限（当前 ${g.permission || DEFAULT_PERMISSION}）`;
   nameBadge.addEventListener("click", (ev) => {
     ev.stopPropagation();
-    if (!connected) return;
+    if (!connection.isConnected()) return;
     showPermissionPopover(node, g);
   });
   li.appendChild(nameBadge);
@@ -407,9 +413,9 @@ function renderGuestRowNormal(li, g, lastGuestLock) {
   } else {
     remove.title = `请离 ${g.name}`;
     remove.addEventListener("click", () => {
-      if (!connected) return;
+      if (!connection.isConnected()) return;
       if (!window.confirm(`请离茶客「${g.name}」？\n房间历史不动，guests/${g.name}/ 工作目录也不会被删，但不会再参与对话。`)) return;
-      ws.send(JSON.stringify({ type: Inbound.REMOVE_GUEST, name: g.name }));
+      send({ type: Inbound.REMOVE_GUEST, name: g.name });
       setStatus("", `请离 ${g.name}…`);
     });
   }
@@ -536,8 +542,8 @@ function renderRoomsList(roomsAvailable, currentRoomId) {
     li.appendChild(meta);
     if (r.room_id !== currentRoomId) {
       li.addEventListener("click", () => {
-        if (!connected) return;
-        ws.send(JSON.stringify({ type: Inbound.SWITCH_ROOM, room_id: r.room_id }));
+        if (!connection.isConnected()) return;
+        send({ type: Inbound.SWITCH_ROOM, room_id: r.room_id });
         setStatus("", `切换到 ${r.name || r.room_id}…`);
       });
       // 删除房间按钮 —— 只对非当前房显示。当前房不能删（先切走再删，与 server 端约束一致）。
@@ -548,9 +554,9 @@ function renderRoomsList(roomsAvailable, currentRoomId) {
       remove.title = `删除房间 ${r.name || r.room_id}`;
       remove.addEventListener("click", (ev) => {
         ev.stopPropagation();
-        if (!connected) return;
+        if (!connection.isConnected()) return;
         if (!window.confirm(`删除房间「${r.name || r.room_id}」？\n房间目录及其全部历史 / 摘要 / 茶客工作区会被永久删除，无法撤销。`)) return;
-        ws.send(JSON.stringify({ type: Inbound.DELETE_ROOM, room_id: r.room_id }));
+        send({ type: Inbound.DELETE_ROOM, room_id: r.room_id });
         setStatus("", `删除 ${r.name || r.room_id}…`);
       });
       li.appendChild(remove);
@@ -849,78 +855,24 @@ function handleEnvelope(env) {
   }
 }
 
-// ── ws 连接 + 重连退避 ─────────────────────────────────────────────
-
-// 退避梯度（ms）。超过梯度长度后稳定在最后一档，永远尝试 —— 桌面 App 无云端账号，
-// 用户没退就接着连；不退指数到分钟级避免长时间断线后用户等不及。
-const RECONNECT_BACKOFF_MS = [1000, 2000, 5000, 10000];
-
-// 这些 close code 表示对端"主动且无意挽回"，不自动重连：
-//   1000 normal closure（双方约定关）
-//   1001 going away（页面切走 / 后端 quit）
-//   1008 policy violation（server.py 拒第二客户端 —— 重连只会再次被拒）
-const NO_RECONNECT_CODES = new Set([1000, 1001, 1008]);
-
-let reconnectAttempt = 0;
-
-function reconnectDelayMs() {
-  const i = Math.min(reconnectAttempt, RECONNECT_BACKOFF_MS.length - 1);
-  return RECONNECT_BACKOFF_MS[i];
-}
-
-function scheduleReconnect() {
-  const delay = reconnectDelayMs();
-  reconnectAttempt += 1;
-  setStatus("error", `连接断开 —— 第 ${reconnectAttempt} 次重试，${delay / 1000}s 后…`);
-  // P3.3 加"立即重连 / 停止重连"按钮时再持有 timer 引用便于 clearTimeout。
-  setTimeout(connect, delay);
-}
-
-function connect() {
-  // 重试中文案 vs 首次连接区分开 —— 首次空白，重试带次数。
-  const tag = reconnectAttempt > 0 ? `（第 ${reconnectAttempt} 次重试）` : "";
-  setStatus("", `连接中… ${wsUrl}${tag}`);
+// ── ws 断线清理 ────────────────────────────────────────────────────
+// connection.js 在 ws close 时回调本函数 —— 重连决策（退避 / NO_RECONNECT_CODES）
+// 留在模块内，这里只做 renderer 侧状态归位。
+function handleDisconnect(code) {
   setInputEnabled(false);
-  ws = new WebSocket(wsUrl);
-  ws.addEventListener("open", () => {
-    connected = true;
-    reconnectAttempt = 0;
-    setStatus("ok", `已连接 ${wsUrl}（等 room_info）`);
-    // composer 解锁延迟到 renderSidebar —— 让 user echo 名字、@ 候选都准备就绪
-    // 后再让用户能输入；避免 "我" → 真名跳变 + @ 候选空白窗口。
-  });
-  ws.addEventListener("message", (ev) => {
-    try {
-      handleEnvelope(JSON.parse(ev.data));
-    } catch (e) {
-      console.error("envelope parse failed:", e, ev.data);
-    }
-  });
-  ws.addEventListener("close", (ev) => {
-    connected = false;
-    setInputEnabled(false);
-    closeInFlightOnDisconnect();
-    // handoff 队列预览是 per-connection 瞬态：断线期间漏收的 handoff_consumed /
-    // handoff_cleared 不会补发，服务端也可能已重启换了空队列 —— 留着旧预览会误导，
-    // 且点 ✕ 会发 handoff_clear 误取消正在跑的 turn。断线即清，与"刷新即清"同口径；
-    // 重连后 renderSidebar 房间 id 不变不会再清，靠这里兜底。
-    handoffState.reset();
-    // P8.3：MTS 状态条同断线即清（与 handoff 预览同口径）。
-    managedSession?.reset();
-    // 拒绝所有等 echo 的上传，让 change handler 的 finally 清 isUploading + 启用附件按钮。
-    upload.dropPending(`ws closed (${ev.code})`);
-    // 断线时 turn_end 不会再来；本地清"停止"状态，让重连成功后按钮回到"发送"。
-    currentTurnId = null;
-    updateSendButton();
-    if (NO_RECONNECT_CODES.has(ev.code)) {
-      setStatus("error", `连接断开 (${ev.code} ${ev.reason || ""})`);
-      return;
-    }
-    scheduleReconnect();
-  });
-  ws.addEventListener("error", (ev) => {
-    console.error("ws error", ev);
-  });
+  closeInFlightOnDisconnect();
+  // handoff 队列预览是 per-connection 瞬态：断线期间漏收的 handoff_consumed /
+  // handoff_cleared 不会补发，服务端也可能已重启换了空队列 —— 留着旧预览会误导，
+  // 且点 ✕ 会发 handoff_clear 误取消正在跑的 turn。断线即清，与"刷新即清"同口径；
+  // 重连后 renderSidebar 房间 id 不变不会再清，靠这里兜底。
+  handoffState.reset();
+  // P8.3：MTS 状态条同断线即清（与 handoff 预览同口径）。
+  managedSession?.reset();
+  // 拒绝所有等 echo 的上传，让 change handler 的 finally 清 isUploading + 启用附件按钮。
+  upload.dropPending(`ws closed (${code})`);
+  // 断线时 turn_end 不会再来；本地清"停止"状态，让重连成功后按钮回到"发送"。
+  currentTurnId = null;
+  updateSendButton();
 }
 
 // ── 添加茶客 / 新建房间 modal ─────────────────────────────────────────
@@ -934,19 +886,19 @@ function closeModal(modal) {
 }
 
 addGuestBtn.addEventListener("click", () => {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   const inRoom = new Set(guests.map((g) => g.name));
   renderPersonaPicker(addGuestListEl, {
     personas: personasAvailable,
     multi: false,
     excludeNames: inRoom,
     onPick: (p) => {
-      ws.send(JSON.stringify({
+      send({
         type: Inbound.ADD_GUEST,
         persona: p.persona,
         name: p.name,
         permission: DEFAULT_PERMISSION,
-      }));
+      });
       setStatus("", `添加茶客 ${p.name}…`);
       closeModal(addGuestModal);
     },
@@ -958,7 +910,7 @@ addGuestBtn.addEventListener("click", () => {
 assignHandoffBtn.addEventListener("click", openAssignPopover);
 
 addRoomBtn.addEventListener("click", () => {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   newRoomNameEl.value = "";
   newRoomTopicEl.value = "";
   newRoomRulesEl.value = "";
@@ -978,14 +930,14 @@ createPersonaImport({
   githubUrlEl: importGithubUrlEl,
   submitBtn: importPersonaSubmitBtn,
   importBtn: importPersonaBtn,
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
   send,
   setStatus,
   pickFolder: window.chahua?.pickFolder,
 });
 
 newRoomSubmitEl.addEventListener("click", () => {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   const name = newRoomNameEl.value.trim();
   if (!name) {
     newRoomNameEl.focus();
@@ -1003,14 +955,14 @@ newRoomSubmitEl.addEventListener("click", () => {
   }));
   // room_id 用 name 直接当目录名 —— server 端 normalize_room_id 会再洗一遍非法字符；
   // 暴露独立 id 字段会增加 UI 复杂度（用户难以理解 id vs name 的区别）。
-  ws.send(JSON.stringify({
+  send({
     type: Inbound.CREATE_ROOM,
     room_id: name,
     name,
     topic: newRoomTopicEl.value.trim(),
     rules: newRoomRulesEl.value.trim(),
     guests: guestsPayload,
-  }));
+  });
   setStatus("", `新建房间 ${name}…`);
   closeModal(addRoomModal);
 });
@@ -1036,19 +988,19 @@ const settings = createSettings({
     submitBtn: roomTomlSubmitBtn,
   },
   avatarFileInput,
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
   send,
   setStatus,
 });
 
 const guestSettings = createGuestSettings({
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
   send,
   setStatus,
 });
 
 const roomSettings = createRoomSettings({
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
   send,
   setStatus,
   openGuestSettings: (g) => guestSettings.open(g),
@@ -1058,14 +1010,14 @@ const roomSettings = createRoomSettings({
 permissionPopover = createPermissionPopover({
   send,
   setStatus,
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
   openGuestSettings: (g) => guestSettings.open(g),
 });
 
 assignPopover = createAssignPopover({
   send,
   setStatus,
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
   getGuests: () => guests.map((g) => g.name),
   getMaxAiTurns: () => maxAiTurns,
 });
@@ -1075,7 +1027,7 @@ assignPopover = createAssignPopover({
 const handoffQueueBar = createHandoffQueueBar({
   barEl: handoffQueueBarEl,
   send,
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
 });
 handoffState.subscribe((queue) => handoffQueueBar.render(queue));
 
@@ -1083,7 +1035,7 @@ handoffState.subscribe((queue) => handoffQueueBar.render(queue));
 // managed_session_* envelope；与 handoff 队列同瞬态——切房 / 断线即 reset。
 managedSession = createManagedSession({
   send,
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
   setStatus,
   getGuests: () => guests.map((g) => g.name),
   getActiveTask: () => taskState.getActiveTask(),
@@ -1096,7 +1048,7 @@ const upload = createUpload({
   pendingFilesEl,
   fileInputEl,
   attachFileBtn,
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
   send,
   setStatus,
   onAttachToTask: (rel) => attachArtifact(rel),
@@ -1111,7 +1063,7 @@ const decisionSupport = createDecisionSupport({
   setStatus,
   openModal,
   closeModal,
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
 });
 
 function attachArtifact(rel) {
@@ -1134,7 +1086,7 @@ function attachArtifact(rel) {
 // dropdown 里切 active"走完全同一行 wire 帧。
 const composerTaskChip = createComposerTaskChip({
   chipEl: composerTaskChipEl,
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
   send,
   setStatus,
   taskState,
@@ -1155,7 +1107,7 @@ const taskPanel = createTaskPanel({
   // 终结态在本层 smart-route 到 close_task vs update_task wire frame。task_panel.js 对
   // wire 协议零感知。
   onPatchTask: (taskId, patch) => {
-    if (!connected) return;
+    if (!connection.isConnected()) return;
     if (patch.status && isTaskClosed(patch.status)) {
       send({ type: Inbound.CLOSE_TASK, task_id: taskId, status: patch.status });
       setStatus("", patch.status === "done" ? "标记完成…" : "放弃任务…");
@@ -1173,7 +1125,7 @@ const taskPanel = createTaskPanel({
   // 产物 li 点击：发 download_file inbound，等 FILE_DOWNLOAD envelope 回吐后 Blob 触发
   // 浏览器原生下载。断网时早返避免 send 抛。
   onDownloadArtifact: (rel) => {
-    if (!connected) return;
+    if (!connection.isConnected()) return;
     send({ type: Inbound.DOWNLOAD_FILE, rel });
     setStatus("", `下载「${rel}」…`);
   },
@@ -1249,7 +1201,7 @@ taskState.subscribe((state) => {
 });
 
 taskPanelNewBtn.addEventListener("click", () => {
-  if (!connected || taskPanelNewBtn.disabled) return;
+  if (!connection.isConnected() || taskPanelNewBtn.disabled) return;
   newTaskTitleEl.value = "";
   newTaskGoalEl.value = "";
   // owner 选项与任务卡 owner 下拉同源 —— "" 表示全员，submit 时再 normalize 回 null。
@@ -1266,7 +1218,7 @@ taskPanelNewBtn.addEventListener("click", () => {
 });
 
 newTaskSubmitBtn.addEventListener("click", () => {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   const title = newTaskTitleEl.value.trim();
   if (!title) {
     newTaskTitleEl.focus();
@@ -1289,7 +1241,7 @@ newTaskSubmitBtn.addEventListener("click", () => {
 // id 的 li 一律跳过 —— 决策必须能引回 transcript 里的真实 message。
 // 标为决策 modal —— 见 ./decision_support.js（factory 实例化在 createUpload 之后）。
 messagesEl.addEventListener("contextmenu", (ev) => {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   const li = ev.target.closest("li[data-message-id]");
   if (!li) return;
   ev.preventDefault();
@@ -1330,10 +1282,10 @@ document.addEventListener("keydown", (ev) => {
 // room_history(空)，renderSidebar 一帧 messagesEl.replaceChildren；失败 / 服务端拒收
 // 时 UI 不会出现"明明清了又冒出来"的诡异状态。
 function clearCurrentRoom() {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   const roomName = roomNameEl.textContent;
   if (!window.confirm(`确定清空「${roomName}」的全部聊天记录？\n茶客在场，但本房间的 transcript / 摘要 / 游标会被重置。`)) return;
-  ws.send(JSON.stringify({ type: Inbound.CLEAR_ROOM }));
+  send({ type: Inbound.CLEAR_ROOM });
   // 服务端 reset_room 会清 handoff 队列，但回环的 room_info 房间 id 不变 ——
   // renderSidebar 的切房判定不会触发，这里显式 reset 让预览跟上。
   handoffState.reset();
@@ -1350,7 +1302,7 @@ function showActionPopover(anchor, title, items) {
 }
 
 function showUserActionsPopover(anchor) {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   showActionPopover(anchor, "我（设置）", [
     { label: "编辑配置", desc: "改 USER.md（显示名 / 个人偏好）", onClick: settings.openEditUserMd },
     { label: "换头像", desc: "PNG / JPG / WebP / GIF，自动裁方 + 压到 256px PNG", onClick: settings.pickAvatarFile },
@@ -1358,7 +1310,7 @@ function showUserActionsPopover(anchor) {
 }
 
 function showRoomActionsPopover(anchor) {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   const roomName = roomNameEl.textContent || "本房间";
   showActionPopover(anchor, `房间「${roomName}」`, [
     { label: "详细设置", desc: "编排参数 / 打分 / 摘要模型 / 茶客一览", onClick: () => roomSettings.open() },
@@ -1369,7 +1321,7 @@ function showRoomActionsPopover(anchor) {
 }
 
 function exportCurrentRoom() {
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   send({ type: Inbound.EXPORT_ROOM });
   setStatus("", "导出中…");
 }
@@ -1393,7 +1345,7 @@ roomNameEl.addEventListener("dblclick", (ev) => {
 // 斜杠命令处理器 —— composer submit 时 tryHandle(text) 优先拦截。clearInput 复刻
 // 原内联的"清空 textarea + 重算高度"两步。
 const commands = createCommands({
-  isConnected: () => connected,
+  isConnected: connection.isConnected,
   send,
   setStatus,
   appendBubble,
@@ -1412,12 +1364,12 @@ composer.addEventListener("submit", (ev) => {
     // dropdown 开着时 Enter 已在 keydown 里被消费；这里防御性 noop。
     return;
   }
-  if (!connected) return;
+  if (!connection.isConnected()) return;
   // 「停止」分支：currentTurnId 非空表示 AI 链在跑，submit 按钮处于「停止」语义。
   // 服务端收到后 task.cancel() 当前 turn task，turn_end(status=cancelled) 回来时
   // 状态机会清掉 currentTurnId，按钮自动复原成「发送」。textInput 内容不动。
   if (currentTurnId !== null) {
-    ws.send(JSON.stringify({ type: Inbound.CANCEL, turn_id: currentTurnId }));
+    send({ type: Inbound.CANCEL, turn_id: currentTurnId });
     setStatus("", "已请求停止…");
     return;
   }
@@ -1446,11 +1398,11 @@ composer.addEventListener("submit", (ev) => {
     kind: "user",
     taskId: taskState.getActiveTask()?.id ?? null,
   });
-  ws.send(JSON.stringify({
+  send({
     type: Inbound.USER_MESSAGE,
     text,
     ...(files.length > 0 ? { files } : {}),
-  }));
+  });
   textInput.value = "";
   upload.clear();
   autoResizeTextarea();
@@ -1467,4 +1419,4 @@ messagesEl.addEventListener("click", (ev) => {
 // 浏览器对 rows="1" 的默认高度算法有 1~2 px 差异 —— 一次 resize 把 textarea
 // 锁到 CSS min-height (36px)，与发送 / 附件按钮单行视图三者对齐。
 autoResizeTextarea();
-connect();
+connection.start();

--- a/app/renderer/renderer.js
+++ b/app/renderer/renderer.js
@@ -60,6 +60,7 @@ import { createChatStream } from "./chat_stream.js";
 import { createMessageFilter } from "./message_filter.js";
 import { createCommands } from "./commands.js";
 import { createConnection } from "./connection.js";
+import { createRoomList } from "./room_list.js";
 
 const statusEl = document.getElementById("status");
 const messagesEl = document.getElementById("messages");
@@ -145,6 +146,15 @@ const connection = createConnection({
 });
 const send = connection.send;
 
+// 侧栏房间列表 + P9「进行中」后台房徽标 —— 见 ./room_list.js。后台房集合封在模块内，
+// renderer 经 render（room_info 重建）/ onBackgroundMilestone（后台里程碑）两出口交互。
+const roomList = createRoomList({
+  roomsEl,
+  isConnected: connection.isConnected,
+  send,
+  setStatus,
+});
+
 // chat-stream（气泡 / 流式 / 历史回放）见 ./chat_stream.js；在途消息 Map 封装在
 // 该模块内，外部只通过 ``closeInFlightOnDisconnect`` 一键清。
 // 当前 turn 的 id —— P3.3 cancel 状态机：turn_start 时设、turn_end(next=user) 或
@@ -163,11 +173,8 @@ let scoresByName = new Map();
 let handoffRoomId = null;
 // P9：当前前台房间在 envelope 里的 room_id（= room.name，见 chahua/events.py）。
 // 从 room_info envelope 顶层 room_id 捕获。后台房间的里程碑事件 room_id 与此不同 ——
-// 据此把它们分流给 handleBackgroundMilestone，不让它们污染前台聊天 / 任务面板。
+// 据此把它们分流给 roomList.onBackgroundMilestone，不让它们污染前台聊天 / 任务面板。
 let foregroundRoomId = null;
-// P9：当前判定「进行中」的后台房间 envelope room_id 集合。后台里程碑事件 add、
-// room_background_finished remove；renderRoomsList 据此渲染房间列表「进行中」徽标。
-const backgroundActiveRooms = new Set();
 // 茶客行 → 打分 span 的引用。sidebar 装好后填，turn_start/turn_end 直接改文字，
 // 不重建 DOM（避免头像 / 徽章闪烁）。
 const scoreSpansByName = new Map();
@@ -497,96 +504,13 @@ function renderSidebar(roomInfo) {
   personasAvailable = Array.isArray(roomInfo.personas_available) ? roomInfo.personas_available : [];
   maxAiTurns = roomInfo.orchestrator?.max_consecutive_ai_turns ?? 20;
   renderGuests();
-  // P9：从权威快照 rooms_available[].busy 重建「进行中」后台房集合 —— 切房 / 重连后
-  // 这帧是真理源（剔除已结束的、补上切走后转后台的）。后台房集合按 envelope room_id
-  // （= room.name）键，与 discover_rooms 的 r.name 同口径；当前房不计（自身活动由
-  // 聊天区体现，不需徽标）。随后到的后台里程碑事件再增量维护这个集合。
-  backgroundActiveRooms.clear();
-  for (const r of roomInfo.rooms_available ?? []) {
-    if (r.busy && r.room_id !== roomInfo.current_room_id) {
-      backgroundActiveRooms.add(r.name);
-    }
-  }
-  renderRoomsList(roomInfo.rooms_available, roomInfo.current_room_id);
+  // 房间列表 + P9「进行中」后台房徽标（见 ./room_list.js）—— render 内部从权威快照
+  // rooms_available[].busy 重建后台房集合再渲染。
+  roomList.render(roomInfo.rooms_available, roomInfo.current_room_id);
   // room_info 到达 → composer 解锁；之前 onopen 不再 enable，避免 userDisplayName
   // 跳变窗口（用户在 "我" 状态发了一条，第二条又变成实际显示名）。
   setInputEnabled(true);
   textInput.focus();
-}
-
-// 切换房间列表 —— 列其它房间（含当前），click 非 current 项发 switch_room frame。
-// 当前房间高亮、不可点；其它房间显示 name + topic 一句话预览，hover 出现"删除"按钮。
-function renderRoomsList(roomsAvailable, currentRoomId) {
-  roomsEl.replaceChildren();
-  const rooms = Array.isArray(roomsAvailable) ? roomsAvailable : [];
-  for (const r of rooms) {
-    const li = document.createElement("li");
-    li.dataset.roomId = r.room_id;
-    // P9：后台房徽标按 envelope room_id（= room.name）匹配 —— 存 r.name 供
-    // refreshRoomBadges 查（envelope 顶层 room_id 用 room.name，不是目录名）。
-    li.dataset.roomName = r.name || r.room_id;
-    if (r.room_id === currentRoomId) li.classList.add("current");
-    // text 块外裹 .room-meta，方便 row-remove 用 margin-left:auto 推到右侧。
-    const meta = document.createElement("div");
-    meta.className = "room-meta";
-    const name = document.createElement("div");
-    name.className = "room-name";
-    name.textContent = r.name || r.room_id;
-    meta.appendChild(name);
-    if (r.topic) {
-      const topic = document.createElement("div");
-      topic.className = "room-topic";
-      topic.textContent = r.topic;
-      meta.appendChild(topic);
-    }
-    li.appendChild(meta);
-    if (r.room_id !== currentRoomId) {
-      li.addEventListener("click", () => {
-        if (!connection.isConnected()) return;
-        send({ type: Inbound.SWITCH_ROOM, room_id: r.room_id });
-        setStatus("", `切换到 ${r.name || r.room_id}…`);
-      });
-      // 删除房间按钮 —— 只对非当前房显示。当前房不能删（先切走再删，与 server 端约束一致）。
-      const remove = document.createElement("button");
-      remove.type = "button";
-      remove.className = "row-icon-btn row-remove";
-      remove.textContent = "×";
-      remove.title = `删除房间 ${r.name || r.room_id}`;
-      remove.addEventListener("click", (ev) => {
-        ev.stopPropagation();
-        if (!connection.isConnected()) return;
-        if (!window.confirm(`删除房间「${r.name || r.room_id}」？\n房间目录及其全部历史 / 摘要 / 茶客工作区会被永久删除，无法撤销。`)) return;
-        send({ type: Inbound.DELETE_ROOM, room_id: r.room_id });
-        setStatus("", `删除 ${r.name || r.room_id}…`);
-      });
-      li.appendChild(remove);
-    }
-    roomsEl.appendChild(li);
-  }
-  refreshRoomBadges();
-}
-
-// P9：按 backgroundActiveRooms 集合刷新房间列表「进行中」徽标 —— 不重建整个列表
-// （避免后台事件高频到达时房间列表闪烁）。徽标只挂非当前房；当前房自身活动由聊天区
-// 体现。徽标元素增量挂 / 摘，不动其余 DOM。
-function refreshRoomBadges() {
-  // [...children] 快照 —— 当前循环只改 li 内的徽标 span、不增删 li，但 children 是
-  // live HTMLCollection，快照后即便将来改成增删 li 也不会漏元素。
-  for (const li of [...roomsEl.children]) {
-    const active =
-      !li.classList.contains("current") &&
-      backgroundActiveRooms.has(li.dataset.roomName);
-    let badge = li.querySelector(".room-busy-badge");
-    if (active && !badge) {
-      badge = document.createElement("span");
-      badge.className = "room-busy-badge";
-      badge.textContent = "进行中";
-      badge.title = "该房间正在后台续跑";
-      li.querySelector(".room-name")?.appendChild(badge);
-    } else if (!active && badge) {
-      badge.remove();
-    }
-  }
 }
 
 // ── @ 补全 + composer 键盘 ────────────────────────────────────────────
@@ -643,21 +567,6 @@ textInput.addEventListener("blur", () => {
 
 // ── envelope 分派 ────────────────────────────────────────────────
 
-// P9：后台房间里程碑事件 —— 只维护「进行中」房间集合 + 刷新房间列表徽标。
-// room_background_finished = 后台 runtime 跑完自毁 → 该房不再「进行中」；其余里程碑
-// （turn_* / message_end / task_* / managed_session_*）→ 标记该房后台仍在跑。
-function handleBackgroundMilestone(env) {
-  const roomId = env.room_id;
-  if (!roomId) return;
-  if (env.type === EventType.ROOM_BACKGROUND_FINISHED) {
-    backgroundActiveRooms.delete(roomId);
-    console.debug("[room_background_finished]", roomId);
-  } else {
-    backgroundActiveRooms.add(roomId);
-  }
-  refreshRoomBadges();
-}
-
 function handleEnvelope(env) {
   // P9：后台房间里程碑分流 —— envelope.room_id 与前台不同、且属后台白名单类型
   // （turn_* / message_end / task_info / task_artifact_added / managed_session_* /
@@ -671,7 +580,7 @@ function handleEnvelope(env) {
     env.room_id !== foregroundRoomId &&
     BACKGROUND_MILESTONE_TYPES.has(env.type)
   ) {
-    handleBackgroundMilestone(env);
+    roomList.onBackgroundMilestone(env);
     return;
   }
   // 调试抽屉旁路消费 —— 模块内部按 env.type dispatch；ROOM_INFO 的 reset 在

--- a/app/renderer/renderer.js
+++ b/app/renderer/renderer.js
@@ -16,9 +16,7 @@
 
 import {
   Inbound,
-  DEFAULT_PERMISSION,
   TASK_UNTITLED,
-  buildOwnerOptionData,
   isTaskClosed,
 } from "./events.js";
 import {
@@ -28,7 +26,7 @@ import {
 import { createSidebar } from "./sidebar.js";
 import { createMention } from "./mention.js";
 import { createUpload } from "./upload.js";
-import { renderPersonaPicker, createPersonaImport } from "./persona.js";
+import { wireModals } from "./modals.js";
 import { createSettings } from "./settings.js";
 import { createGuestSettings } from "./guest_settings.js";
 import { createRoomSettings } from "./room_settings.js";
@@ -69,19 +67,8 @@ const addGuestBtn = document.getElementById("add-guest");
 const importPersonaBtn = document.getElementById("import-persona");
 const assignHandoffBtn = document.getElementById("assign-handoff");
 const addRoomBtn = document.getElementById("add-room");
-const addGuestModal = document.getElementById("add-guest-modal");
-const addRoomModal = document.getElementById("add-room-modal");
-const importPersonaModal = document.getElementById("import-persona-modal");
-const addGuestListEl = document.getElementById("add-guest-list");
-const newRoomNameEl = document.getElementById("new-room-name");
-const newRoomTopicEl = document.getElementById("new-room-topic");
-const newRoomRulesEl = document.getElementById("new-room-rules");
-const newRoomGuestsEl = document.getElementById("new-room-guests");
-const newRoomSubmitEl = document.getElementById("new-room-submit");
-const importFolderPathEl = document.getElementById("import-folder-path");
-const importFolderPickBtn = document.getElementById("import-folder-pick");
-const importGithubUrlEl = document.getElementById("import-github-url");
-const importPersonaSubmitBtn = document.getElementById("import-persona-submit");
+// 添加茶客 / 新建房间 / 新建任务 / 导入 persona 四个 modal 的 DOM 节点在 ./modals.js
+// 内自取（仅那里用）。
 const avatarFileInput = document.getElementById("avatar-file-input");
 const editUserModal = document.getElementById("edit-user-modal");
 const userMdTextarea = document.getElementById("user-md-textarea");
@@ -107,11 +94,6 @@ const debugPanelBackBtn = document.getElementById("debug-panel-back");
 const debugPanelClearBtn = document.getElementById("debug-panel-clear");
 const composerTaskChipEl = document.getElementById("composer-task-chip");
 const handoffQueueBarEl = document.getElementById("handoff-queue-bar");
-const newTaskModal = document.getElementById("new-task-modal");
-const newTaskTitleEl = document.getElementById("new-task-title");
-const newTaskGoalEl = document.getElementById("new-task-goal");
-const newTaskOwnerEl = document.getElementById("new-task-owner");
-const newTaskSubmitBtn = document.getElementById("new-task-submit");
 const markDecisionModal = document.getElementById("mark-decision-modal");
 const markDecisionSummaryEl = document.getElementById("mark-decision-summary");
 const markDecisionSupportEl = document.getElementById("mark-decision-support");
@@ -424,8 +406,8 @@ function handleDisconnect(code) {
   turnState.clear();
 }
 
-// ── 添加茶客 / 新建房间 modal ─────────────────────────────────────────
-
+// ── modal ────────────────────────────────────────────────────────────
+// openModal / closeModal 是 modal 显隐的单点（modals.js 与 decision_support 共用）。
 function openModal(modal) {
   modal.hidden = false;
 }
@@ -434,87 +416,21 @@ function closeModal(modal) {
   modal.hidden = true;
 }
 
-addGuestBtn.addEventListener("click", () => {
-  if (!connection.isConnected()) return;
-  const inRoom = new Set(guests.map((g) => g.name));
-  renderPersonaPicker(addGuestListEl, {
-    personas: personasAvailable,
-    multi: false,
-    excludeNames: inRoom,
-    onPick: (p) => {
-      send({
-        type: Inbound.ADD_GUEST,
-        persona: p.persona,
-        name: p.name,
-        permission: DEFAULT_PERMISSION,
-      });
-      setStatus("", `添加茶客 ${p.name}…`);
-      closeModal(addGuestModal);
-    },
-  });
-  openModal(addGuestModal);
+// 添加茶客 / 新建房间 / 新建任务 / 导入 persona 四个 modal 的装配在 ./modals.js ——
+// 模块自取 DOM 节点，全 modal 的「点 backdrop / × / ESC 关闭」兜底也一并挂。
+wireModals({
+  isConnected: connection.isConnected,
+  send,
+  setStatus,
+  getGuests: () => guests,
+  getPersonas: () => personasAvailable,
+  pickFolder: window.chahua?.pickFolder,
+  openModal,
+  closeModal,
 });
 
 // composer 底栏「指派」按钮 —— 弹统一的指派 / 圆桌 popover。
 assignHandoffBtn.addEventListener("click", openAssignPopover);
-
-addRoomBtn.addEventListener("click", () => {
-  if (!connection.isConnected()) return;
-  newRoomNameEl.value = "";
-  newRoomTopicEl.value = "";
-  newRoomRulesEl.value = "";
-  renderPersonaPicker(newRoomGuestsEl, {
-    personas: personasAvailable,
-    multi: true,
-    excludeNames: null,
-  });
-  openModal(addRoomModal);
-  newRoomNameEl.focus();
-});
-
-createPersonaImport({
-  modal: importPersonaModal,
-  folderPathEl: importFolderPathEl,
-  folderPickBtn: importFolderPickBtn,
-  githubUrlEl: importGithubUrlEl,
-  submitBtn: importPersonaSubmitBtn,
-  importBtn: importPersonaBtn,
-  isConnected: connection.isConnected,
-  send,
-  setStatus,
-  pickFolder: window.chahua?.pickFolder,
-});
-
-newRoomSubmitEl.addEventListener("click", () => {
-  if (!connection.isConnected()) return;
-  const name = newRoomNameEl.value.trim();
-  if (!name) {
-    newRoomNameEl.focus();
-    return;
-  }
-  const selected = Array.from(newRoomGuestsEl.querySelectorAll("li.persona-item.selected"));
-  if (selected.length === 0) {
-    window.alert("至少选 1 位茶客");
-    return;
-  }
-  const guestsPayload = selected.map((li) => ({
-    persona: li.dataset.persona,
-    name: li.dataset.name,
-    permission: DEFAULT_PERMISSION,
-  }));
-  // room_id 用 name 直接当目录名 —— server 端 normalize_room_id 会再洗一遍非法字符；
-  // 暴露独立 id 字段会增加 UI 复杂度（用户难以理解 id vs name 的区别）。
-  send({
-    type: Inbound.CREATE_ROOM,
-    room_id: name,
-    name,
-    topic: newRoomTopicEl.value.trim(),
-    rules: newRoomRulesEl.value.trim(),
-    guests: guestsPayload,
-  });
-  setStatus("", `新建房间 ${name}…`);
-  closeModal(addRoomModal);
-});
 
 // ── 我（USER.md / 头像）─────────────────────────────────────────────
 
@@ -764,42 +680,6 @@ taskState.subscribe((state) => {
   managedSession?.refresh();
 });
 
-taskPanelNewBtn.addEventListener("click", () => {
-  if (!connection.isConnected() || taskPanelNewBtn.disabled) return;
-  newTaskTitleEl.value = "";
-  newTaskGoalEl.value = "";
-  // owner 选项与任务卡 owner 下拉同源 —— "" 表示全员，submit 时再 normalize 回 null。
-  newTaskOwnerEl.replaceChildren();
-  for (const data of buildOwnerOptionData(guests.map((g) => g.name))) {
-    const opt = document.createElement("option");
-    opt.value = data.value;
-    opt.textContent = data.label;
-    newTaskOwnerEl.appendChild(opt);
-  }
-  newTaskOwnerEl.value = "";
-  openModal(newTaskModal);
-  newTaskTitleEl.focus();
-});
-
-newTaskSubmitBtn.addEventListener("click", () => {
-  if (!connection.isConnected()) return;
-  const title = newTaskTitleEl.value.trim();
-  if (!title) {
-    newTaskTitleEl.focus();
-    return;
-  }
-  const ownerRaw = newTaskOwnerEl.value;
-  const payload = {
-    type: Inbound.OPEN_TASK,
-    title,
-    goal: newTaskGoalEl.value,
-    owner: ownerRaw === "" ? null : ownerRaw,
-  };
-  send(payload);
-  setStatus("", `新建任务「${title}」…`);
-  closeModal(newTaskModal);
-});
-
 // 决策入口：右键消息气泡 → action popover → modal。message_id 仅在 server 落盘后
 // 才挂到 li 上（用户自己 echo 的那条没有，直到下次 room_history 才补），所以未带
 // id 的 li 一律跳过 —— 决策必须能引回 transcript 里的真实 message。
@@ -821,25 +701,6 @@ messagesEl.addEventListener("contextmenu", (ev) => {
       onClick: () => decisionSupport.open(li, active.id),
     },
   ]);
-});
-
-// modal 关闭：点 backdrop（modal-backdrop 自身、不是内部 .modal）/ × 按钮 / ESC。
-const editGuestModal = document.getElementById("edit-guest-modal");
-const editRoomModal = document.getElementById("edit-room-modal");
-const ALL_MODALS = [
-  addGuestModal, addRoomModal, editUserModal, importPersonaModal,
-  editRoomTomlModal, editGuestModal, editRoomModal, newTaskModal,
-  markDecisionModal,
-];
-for (const modal of ALL_MODALS) {
-  modal.addEventListener("click", (ev) => {
-    if (ev.target === modal) closeModal(modal);
-    if (ev.target.matches("[data-close]")) closeModal(modal);
-  });
-}
-document.addEventListener("keydown", (ev) => {
-  if (ev.key !== "Escape") return;
-  for (const m of ALL_MODALS) if (!m.hidden) closeModal(m);
 });
 
 // 清空聊天：本地不抢先清 DOM，让回环一致 —— 服务端清完会重发 room_info +

--- a/app/renderer/renderer.js
+++ b/app/renderer/renderer.js
@@ -61,6 +61,7 @@ import { createMessageFilter } from "./message_filter.js";
 import { createCommands } from "./commands.js";
 import { createConnection } from "./connection.js";
 import { createRoomList } from "./room_list.js";
+import { createTurnState } from "./turn_state.js";
 
 const statusEl = document.getElementById("status");
 const messagesEl = document.getElementById("messages");
@@ -155,17 +156,12 @@ const roomList = createRoomList({
   setStatus,
 });
 
+// 当前 turn 状态 + 发送/停止按钮封在 ./turn_state.js —— renderer 经 isActive /
+// turnId / set / clear / syncToRoom 交互。
+const turnState = createTurnState({ submitBtn });
+
 // chat-stream（气泡 / 流式 / 历史回放）见 ./chat_stream.js；在途消息 Map 封装在
 // 该模块内，外部只通过 ``closeInFlightOnDisconnect`` 一键清。
-// 当前 turn 的 id —— P3.3 cancel 状态机：turn_start 时设、turn_end(next=user) 或
-// status=cancelled 时清；turn_end(next=ai) 不清（下个 turn_start 会刷新）。非 null 即
-// "AI 链在跑"，submit button 切到「停止」语义，submit handler 路由到 cancel 帧。
-let currentTurnId = null;
-// P9：切到一个后台正在跑 turn 的房间时，前端没有那个 turn 的真实 id（turn_start 在
-// 切房前就发过了）。用这个哨兵占位让「停止」按钮正确显示 —— updateSendButton 只看
-// currentTurnId 是否非空、cancel 帧服务端只认 type 不校验 turn_id。真实 turn_start
-// 到达会覆盖它，turn_end 清掉它。
-const FOREGROUND_BUSY_TURN_PLACEHOLDER = "turn_foreground_busy";
 // 当前 turn 的打分明细。turn_start replace / turn_end 清。
 let scoresByName = new Map();
 // renderSidebar 上次渲染的房间 id —— 用来区分"真正切房" vs "同房 room_info 刷新"
@@ -230,11 +226,6 @@ function updateNewTaskBtn() {
   taskPanelNewBtn.title = "新建任务";
 }
 
-// 同一个按钮承担「发送 / 停止」双重职责；aria-label 同步切，屏读器读"发送"/"停止"而
-// 不是裸符号。颜色由 .stop 类 + style.css 控制。
-const SEND_ICON = "↑";
-const STOP_ICON = "■";
-
 // GUEST_CAPS_INFO envelope → system 气泡文案。view 决定列 tools 还是 skills 段
 // （permission / guest 两段共用）。description 取首行 + 截断，避免长描述刷屏。
 function formatGuestCaps(data, view) {
@@ -257,14 +248,6 @@ function formatGuestCaps(data, view) {
   }
   return lines.join("\n");
 }
-function updateSendButton() {
-  const busy = currentTurnId !== null;
-  submitBtn.textContent = busy ? STOP_ICON : SEND_ICON;
-  submitBtn.setAttribute("aria-label", busy ? "停止" : "发送");
-  submitBtn.title = busy ? "停止当前轮次" : "发送 (Enter)";
-  submitBtn.classList.toggle("stop", busy);
-}
-
 function stickToBottom(mutate) {
   const stick = messagesEl.scrollHeight - messagesEl.scrollTop - messagesEl.clientHeight < 80;
   mutate();
@@ -471,14 +454,12 @@ function renderSidebar(roomInfo) {
     handoffRoomId = nextRoomId;
     // P9：切房后旧房在后台续跑 —— 它的 turn_end 不再回到本视图，currentTurnId
     // 不会被旧房收尾事件清掉。必须按**新前台房间**的 busy 快照重置「发送/停止」
-    // 按钮：从忙房切到闲房 → 复原成「发送」；切进一个后台仍在跑的房 → 维持
-    // 「停止」（哨兵占位，真实 turn_start/turn_end 后续会校准）。同房刷新不进
-    // 此分支，currentTurnId 不动（本房 turn 仍在跑时不该误清）。
+    // 按钮（见 turn_state.syncToRoom）。同房刷新不进此分支，turn 状态不动（本房
+    // turn 仍在跑时不该误清）。
     const nextRoom = (roomInfo.rooms_available ?? []).find(
       (r) => r.room_id === nextRoomId,
     );
-    currentTurnId = nextRoom?.busy ? FOREGROUND_BUSY_TURN_PLACEHOLDER : null;
-    updateSendButton();
+    turnState.syncToRoom(!!nextRoom?.busy);
   }
   // sidebar 全量重渲会替掉头像 DOM —— 旧 anchor 一旦被 detach，popover 的"贴右侧"
   // 位置就指向虚空了，干脆关掉。
@@ -603,8 +584,7 @@ function handleEnvelope(env) {
       console.debug("[turn_start]", scores);
       scoresByName = new Map(scores.map((r) => [r.guest_name, r]));
       applyScoresToSidebar();
-      currentTurnId = env.turn_id;
-      updateSendButton();
+      turnState.set(env.turn_id);
       return;
     }
     case EventType.MESSAGE_START:
@@ -623,8 +603,7 @@ function handleEnvelope(env) {
       // 「停止」按钮。next==='ai' 时维持，下一个 turn_start 立刻刷新 currentTurnId。
       const next = env.data?.next;
       if (env.status !== Status.OK || next === "user") {
-        currentTurnId = null;
-        updateSendButton();
+        turnState.clear();
         // AI 链收尾、无 in-flight turn —— 放开被 gate 的 handoff 采纳按钮（此刻采纳
         // 不会抢占截断任何 turn）。next==='ai' 时链未结束，不放。
         proposalCard.onTurnIdle();
@@ -780,8 +759,7 @@ function handleDisconnect(code) {
   // 拒绝所有等 echo 的上传，让 change handler 的 finally 清 isUploading + 启用附件按钮。
   upload.dropPending(`ws closed (${code})`);
   // 断线时 turn_end 不会再来；本地清"停止"状态，让重连成功后按钮回到"发送"。
-  currentTurnId = null;
-  updateSendButton();
+  turnState.clear();
 }
 
 // ── 添加茶客 / 新建房间 modal ─────────────────────────────────────────
@@ -1048,7 +1026,7 @@ const taskPanel = createTaskPanel({
 const proposalCard = createProposalCard({
   messagesEl,
   sendInbound: send,
-  isTurnActive: () => currentTurnId !== null,
+  isTurnActive: turnState.isActive,
 });
 
 // 调试抽屉。默认隐藏 —— 用户点 task panel header 的 🔬 切到；调试内 ← 切回。
@@ -1274,11 +1252,11 @@ composer.addEventListener("submit", (ev) => {
     return;
   }
   if (!connection.isConnected()) return;
-  // 「停止」分支：currentTurnId 非空表示 AI 链在跑，submit 按钮处于「停止」语义。
+  // 「停止」分支：turnState.isActive() 表示 AI 链在跑，submit 按钮处于「停止」语义。
   // 服务端收到后 task.cancel() 当前 turn task，turn_end(status=cancelled) 回来时
-  // 状态机会清掉 currentTurnId，按钮自动复原成「发送」。textInput 内容不动。
-  if (currentTurnId !== null) {
-    send({ type: Inbound.CANCEL, turn_id: currentTurnId });
+  // turn_state 会清掉，按钮自动复原成「发送」。textInput 内容不动。
+  if (turnState.isActive()) {
+    send({ type: Inbound.CANCEL, turn_id: turnState.turnId() });
     setStatus("", "已请求停止…");
     return;
   }

--- a/app/renderer/renderer.js
+++ b/app/renderer/renderer.js
@@ -15,17 +15,11 @@
 // 用户消息（renderer 自己 echo 的那条）不走 envelope path —— 直接 appendBubble。
 
 import {
-  EventType,
-  Status,
   Inbound,
   ScoreKind,
-  NoticeLevel,
   DEFAULT_PERMISSION,
   TASK_UNTITLED,
-  BACKGROUND_MILESTONE_TYPES,
   buildOwnerOptionData,
-  formatTaskEventNotice,
-  formatManagedSessionNotice,
   isTaskClosed,
 } from "./events.js";
 import {
@@ -62,6 +56,7 @@ import { createCommands } from "./commands.js";
 import { createConnection } from "./connection.js";
 import { createRoomList } from "./room_list.js";
 import { createTurnState } from "./turn_state.js";
+import { createEnvelopeRouter } from "./envelope_router.js";
 
 const statusEl = document.getElementById("status");
 const messagesEl = document.getElementById("messages");
@@ -135,14 +130,16 @@ if (!wsUrl) {
 }
 
 // WebSocket 连接 + 重连退避封在 ./connection.js —— renderer 经 send / isConnected
-// 读写连接、经 onConnecting / onMessage / onClose 回调接生命周期。回调引用的
-// handleEnvelope / handleDisconnect / setInputEnabled 都是 hoisted 函数声明，故可在
-// 此处提前装配（feature module 工厂在下文要拿 send，必须早于它们就绪）。
+// 读写连接、经 onConnecting / onMessage / onClose 回调接生命周期。此处提前装配
+// （feature module 工厂在下文要拿 send，必须早于它们就绪）；onMessage 引用的
+// envelopeRouter 在下文才装配，经 arrow 推迟解析。
 const connection = createConnection({
   wsUrl,
   setStatus,
   onConnecting: () => setInputEnabled(false),
-  onMessage: handleEnvelope,
+  // envelopeRouter 在下文 feature 工厂之后才装配 —— arrow 推迟到调用时解析（ws
+  // message 在 connection.start() 之后才到，那时 envelopeRouter 已就绪）。
+  onMessage: (env) => envelopeRouter.handleEnvelope(env),
   onClose: handleDisconnect,
 });
 const send = connection.send;
@@ -167,10 +164,6 @@ let scoresByName = new Map();
 // renderSidebar 上次渲染的房间 id —— 用来区分"真正切房" vs "同房 room_info 刷新"
 // （改头像 / 改设置 / 增删茶客都会重发 room_info）。handoff 队列预览只在真正切房时清。
 let handoffRoomId = null;
-// P9：当前前台房间在 envelope 里的 room_id（= room.name，见 chahua/events.py）。
-// 从 room_info envelope 顶层 room_id 捕获。后台房间的里程碑事件 room_id 与此不同 ——
-// 据此把它们分流给 roomList.onBackgroundMilestone，不让它们污染前台聊天 / 任务面板。
-let foregroundRoomId = null;
 // 茶客行 → 打分 span 的引用。sidebar 装好后填，turn_start/turn_end 直接改文字，
 // 不重建 DOM（避免头像 / 徽章闪烁）。
 const scoreSpansByName = new Map();
@@ -226,28 +219,6 @@ function updateNewTaskBtn() {
   taskPanelNewBtn.title = "新建任务";
 }
 
-// GUEST_CAPS_INFO envelope → system 气泡文案。view 决定列 tools 还是 skills 段
-// （permission / guest 两段共用）。description 取首行 + 截断，避免长描述刷屏。
-function formatGuestCaps(data, view) {
-  const guest = data.guest || "?";
-  const brief = (s) => (s || "").split("\n")[0].slice(0, 100);
-  if (view === "skills") {
-    const skills = Array.isArray(data.skills) ? data.skills : [];
-    const lines = [`**${guest}** 可用 skills（${skills.length}）`];
-    if (!skills.length) lines.push("_（无）_");
-    for (const s of skills) {
-      lines.push(`- \`${s.name}\`${s.description ? ` —— ${brief(s.description)}` : ""}`);
-    }
-    return lines.join("\n");
-  }
-  const tools = Array.isArray(data.tools) ? data.tools : [];
-  const lines = [`**${guest}** 注册的 tools（${tools.length}，权限模式：${data.permission || "?"}）`];
-  for (const t of tools) {
-    const ro = t.is_read_only ? "read-only" : "write";
-    lines.push(`- \`${t.name}\` (${ro})${t.description ? ` —— ${brief(t.description)}` : ""}`);
-  }
-  return lines.join("\n");
-}
 function stickToBottom(mutate) {
   const stick = messagesEl.scrollHeight - messagesEl.scrollTop - messagesEl.clientHeight < 80;
   mutate();
@@ -338,6 +309,13 @@ function applyScoresToSidebar() {
       delete span.dataset.kind;
     }
   }
+}
+
+// turn_start / turn_end 经 envelope_router 调 —— 用打分列表（turn_end 传空）替换
+// scoresByName 并刷 sidebar。renderSidebar 切房也调一次空列表清残留。
+function applyScores(scoresList) {
+  scoresByName = new Map((scoresList ?? []).map((r) => [r.guest_name, r]));
+  applyScoresToSidebar();
 }
 
 // chat-stream 工厂 —— 在所有依赖（messagesEl / makeAvatar / stickToBottom /
@@ -545,203 +523,6 @@ textInput.addEventListener("blur", () => {
   // mousedown 已在 blur 之前完成补全；这里 100ms 后兜底关 dropdown。
   setTimeout(mention.hide, 100);
 });
-
-// ── envelope 分派 ────────────────────────────────────────────────
-
-function handleEnvelope(env) {
-  // P9：后台房间里程碑分流 —— envelope.room_id 与前台不同、且属后台白名单类型
-  // （turn_* / message_end / task_info / task_artifact_added / managed_session_* /
-  // room_background_finished）→ 当作后台房间里程碑，只更新房间列表「进行中」徽标，
-  // 不让它污染前台聊天 / 任务面板 / 调试抽屉。控制面事件（room_info / room_history
-  // / notice 等）不在白名单内 —— 切房时新房 room_info 的 room_id 虽 ≠ 旧前台，仍
-  // 照常落到下面 switch 并由 ROOM_INFO 分支刷新 foregroundRoomId。
-  if (
-    foregroundRoomId !== null &&
-    env.room_id &&
-    env.room_id !== foregroundRoomId &&
-    BACKGROUND_MILESTONE_TYPES.has(env.type)
-  ) {
-    roomList.onBackgroundMilestone(env);
-    return;
-  }
-  // 调试抽屉旁路消费 —— 模块内部按 env.type dispatch；ROOM_INFO 的 reset 在
-  // renderSidebar 里调（与 inFlight / proposalCard 同步清）。
-  debugPanel.onEnvelope(env);
-  switch (env.type) {
-    case EventType.ROOM_INFO:
-      // 前台房间在 envelope 里的 room_id（= room.name）—— 后台分流的判定基准。
-      foregroundRoomId = env.room_id ?? null;
-      renderSidebar(env.data ?? {});
-      return;
-    case EventType.ROOM_HISTORY:
-      renderHistory(env.data?.messages ?? []);
-      // P6.3.A：``turns_index`` 倒序投影注入调试抽屉的历史索引（``debug.enabled=False``
-      // 时整字段缺省 → applyTurnsIndex 不入 array，索引区维持空）。
-      debugPanel.applyTurnsIndex(env.data?.turns_index ?? null);
-      return;
-    case EventType.TURN_START: {
-      const scores = env.data?.scores ?? [];
-      console.debug("[turn_start]", scores);
-      scoresByName = new Map(scores.map((r) => [r.guest_name, r]));
-      applyScoresToSidebar();
-      turnState.set(env.turn_id);
-      return;
-    }
-    case EventType.MESSAGE_START:
-      startStreamingMessage(env);
-      return;
-    case EventType.MESSAGE_DELTA:
-      appendDelta(env);
-      return;
-    case EventType.MESSAGE_END:
-      endStreamingMessage(env);
-      return;
-    case EventType.TURN_END: {
-      scoresByName = new Map();
-      applyScoresToSidebar();
-      // AI 链终态判定：status != ok（cancelled）或 next==='user'（用户该说话了）→ 收
-      // 「停止」按钮。next==='ai' 时维持，下一个 turn_start 立刻刷新 currentTurnId。
-      const next = env.data?.next;
-      if (env.status !== Status.OK || next === "user") {
-        turnState.clear();
-        // AI 链收尾、无 in-flight turn —— 放开被 gate 的 handoff 采纳按钮（此刻采纳
-        // 不会抢占截断任何 turn）。next==='ai' 时链未结束，不放。
-        proposalCard.onTurnIdle();
-      }
-      return;
-    }
-    case EventType.NOTICE: {
-      // 服务端 mutator 的一次性反馈 —— 目前 persona 导入用。错误强提示 alert，
-      // 让用户立刻看到原因；info 走 status bar 不打断流。
-      const level = env.data?.level || NoticeLevel.INFO;
-      const text = env.data?.text || "";
-      if (!text) return;
-      if (level === NoticeLevel.ERROR) {
-        window.alert(text);
-        setStatus("error", text);
-      } else {
-        setStatus("ok", text);
-      }
-      return;
-    }
-    case EventType.FILE_UPLOADED:
-      upload.onServerEcho(env.data ?? {});
-      return;
-    // 任务房间（docs/P5-任务房间.md §4.2）。TASK_INFO 是权威快照 → 全量覆盖 taskState
-    // 让面板重渲；其它 4 个是 hint → 在对应 DOM 上闪一下，权威 state 等紧跟而至的
-    // TASK_INFO 推进。
-    case EventType.TASK_INFO:
-      taskState.setSnapshot(env.data ?? {});
-      return;
-    // P5.8：task hint 既闪面板增量项、又在聊天区追一条居中系统气泡（task event
-    // 不再合成 user 消息进 transcript）。气泡是瞬时 UI 通知，刷新 / 切房即清。
-    case EventType.TASK_OPEN:
-    case EventType.TASK_DECISION_ADDED:
-    case EventType.TASK_ARTIFACT_ADDED:
-    case EventType.TASK_CLOSE: {
-      taskPanel.flashHint(env.type, env.data ?? {});
-      const text = formatTaskEventNotice(env.type, env.data ?? {});
-      if (text) appendBubble({ kind: "system", text });
-      return;
-    }
-    case EventType.TASK_ARTIFACTS_CLEARED: {
-      // 不调 flashHint —— 清空动作没有可高亮的"新增项"，状态推进全靠紧随的
-      // TASK_INFO；本事件唯一价值就是系统气泡。
-      const text = formatTaskEventNotice(env.type, env.data ?? {});
-      if (text) appendBubble({ kind: "system", text });
-      return;
-    }
-    // TASK_UPDATE 不显示气泡 —— 避免用户编辑标题时聊天流被刷。
-    case EventType.TASK_UPDATE:
-      taskPanel.flashHint(env.type, env.data ?? {});
-      return;
-    case EventType.TASK_PROPOSAL:
-      proposalCard.onEnvelope(env);
-      return;
-    // P7.1 显式 handoff（docs/P7 §3.3）。三个事件维护本地队列预览；权威状态就是
-    // 队列本身——服务端不落盘，刷新 / 切房在 renderSidebar 里 reset。
-    case EventType.HANDOFF_ENQUEUED:
-      handoffState.applyEnqueued(env.data?.queue ?? []);
-      return;
-    case EventType.HANDOFF_CONSUMED:
-      handoffState.applyConsumed(env.data?.item ?? null);
-      return;
-    case EventType.HANDOFF_CLEARED:
-      handoffState.applyCleared();
-      return;
-    // P8.3 托管会话（docs/P8.3 §3.4）。三个 hint 事件维护状态条；ended 追系统气泡。
-    case EventType.MANAGED_SESSION_STARTED:
-      managedSession.onStarted(env.data ?? {});
-      return;
-    case EventType.MANAGED_SESSION_ADVANCED:
-      managedSession.onAdvanced(env.data ?? {});
-      return;
-    case EventType.MANAGED_SESSION_ENDED: {
-      const reason = env.data?.reason;
-      managedSession.onEnded(env.data ?? {});
-      appendBubble({ kind: "system", text: formatManagedSessionNotice(reason) });
-      return;
-    }
-    case EventType.GUEST_CAPS_INFO: {
-      // view 由请求方经 envelope 回声带回 —— 多条 /tools / /skills 并发时各响应
-      // 自带"查的是哪段"，不靠全局态对号入座。
-      const data = env.data ?? {};
-      appendBubble({ kind: "system", text: formatGuestCaps(data, data.view) });
-      return;
-    }
-    case EventType.ROOM_EXPORT: {
-      const markdown = env.data?.markdown;
-      const filename = env.data?.filename || "chahua-export.md";
-      if (typeof markdown !== "string") return;
-      // Blob 走 markdown 文本 mime；<a download> 触发浏览器原生下载流程。CSP
-      // 已允许 'self'，blob: URL 在 Chromium 里也通过 default-src 'self'。
-      const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
-      setStatus("ok", `已导出 ${filename}`);
-      return;
-    }
-    case EventType.FILE_DOWNLOAD: {
-      // 失败路径：NOTICE 已弹过 alert，envelope 仅含 {rel, error}，跳过 Blob 流程。
-      const d = env.data || {};
-      if (d.error) return;
-      const b64 = d.content_b64;
-      const name = d.name || "download";
-      if (typeof b64 !== "string") return;
-      // base64 → Uint8Array → Blob。atob 一次性解码 ~200MB 在 Chromium 还稳；超大 base64
-      // 字符串在 ws 入站早就被 _DOWNLOAD_MAX_BYTES 拦了。
-      let bin;
-      try {
-        bin = atob(b64);
-      } catch (e) {
-        setStatus("error", `下载「${name}」失败：base64 解码出错`);
-        return;
-      }
-      const bytes = new Uint8Array(bin.length);
-      for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
-      // 走 application/octet-stream 让浏览器把它当下载而非 inline preview。具体 mime 类型
-      // 由扩展名决定，留给操作系统打开时自己识别。
-      const blob = new Blob([bytes], { type: "application/octet-stream" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = name;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
-      setStatus("ok", `已下载「${name}」`);
-      return;
-    }
-    // guest_thinking / tool_* 暂时静默。
-  }
-}
 
 // ── ws 断线清理 ────────────────────────────────────────────────────
 // connection.js 在 ws close 时回调本函数 —— 重连决策（退避 / NO_RECONNECT_CODES）
@@ -1038,6 +819,26 @@ const debugPanel = createDebugPanel({
   // P6.3.A 点击历史索引行 → FETCH_TURN_DETAIL inbound；服务端回 TURN_DETAIL 经
   // debugPanel.onEnvelope 处理。
   sendInbound: send,
+});
+
+// envelope 分派器 —— ws 下行每帧按 type 分发到各 feature 模块（见 ./envelope_router.js）。
+// 在所有被分发到的 feature 模块就绪之后装配；connection.onMessage 经 arrow 推迟引用。
+const envelopeRouter = createEnvelopeRouter({
+  roomList,
+  debugPanel,
+  renderSidebar,
+  renderHistory,
+  applyScores,
+  turnState,
+  proposalCard,
+  startStreamingMessage,
+  appendDelta,
+  endStreamingMessage,
+  appendBubble,
+  setStatus,
+  upload,
+  taskPanel,
+  managedSession,
 });
 
 // task ↔ debug 互斥占槽：``setVisible(bool)`` 让各自模块持有自家 hidden 不变量，

--- a/app/renderer/renderer.js
+++ b/app/renderer/renderer.js
@@ -16,7 +16,6 @@
 
 import {
   Inbound,
-  ScoreKind,
   DEFAULT_PERMISSION,
   TASK_UNTITLED,
   buildOwnerOptionData,
@@ -26,12 +25,7 @@ import {
   closeActionPopover,
   openActionPopover,
 } from "./ui_popover.js";
-import {
-  makeAvatarImg,
-  scoreText,
-  makeBadge,
-  makePermissionBadge,
-} from "./chat_view.js";
+import { createSidebar } from "./sidebar.js";
 import { createMention } from "./mention.js";
 import { createUpload } from "./upload.js";
 import { renderPersonaPicker, createPersonaImport } from "./persona.js";
@@ -159,38 +153,31 @@ const turnState = createTurnState({ submitBtn });
 
 // chat-stream（气泡 / 流式 / 历史回放）见 ./chat_stream.js；在途消息 Map 封装在
 // 该模块内，外部只通过 ``closeInFlightOnDisconnect`` 一键清。
-// 当前 turn 的打分明细。turn_start replace / turn_end 清。
-let scoresByName = new Map();
 // renderSidebar 上次渲染的房间 id —— 用来区分"真正切房" vs "同房 room_info 刷新"
 // （改头像 / 改设置 / 增删茶客都会重发 room_info）。handoff 队列预览只在真正切房时清。
 let handoffRoomId = null;
-// 茶客行 → 打分 span 的引用。sidebar 装好后填，turn_start/turn_end 直接改文字，
-// 不重建 DOM（避免头像 / 徽章闪烁）。
-const scoreSpansByName = new Map();
-// 茶客名单（room_info 来时装）—— @ 补全候选 + 头像查找 + 用户显示名 / 头像。
+// 茶客名单（room_info 来时装）—— @ 补全候选 + 一众模块（mention / assign / 任务卡
+// owner …）读取。头像 / 打分 / 用户行渲染在 ./sidebar.js，经 getGuests 取这份名单。
 let guests = []; // [{name, permission, isolation, avatar_data_uri}, ...]
-let userDisplayName = "我";
-let userAvatarDataUri = null;
 // 可用 persona 候选（room_info 来时装）—— "添加茶客" / "新建房间"的 picker 用。
 let personasAvailable = []; // [{persona, name, avatar_data_uri}, ...]
 // 房间生效的 max_consecutive_ai_turns（room_info.orchestrator 来时装）—— 圆桌
 // cap 预校验用；缺省 20 与 OrchestratorConfig 默认一致。
 let maxAiTurns = 20;
 
-// 茶客头像 —— 按名字在 guests 数组里 find；茶客 ≤ 个位数，线性查比维护并行 Map 简单
-// （且任何 guests 变更都自动跟上）。
-function makeAvatar(name, className) {
-  return makeAvatarImg(
-    guests.find((g) => g.name === name)?.avatar_data_uri,
-    className,
-    name,
-  );
-}
-
-// 用户头像 —— 走 userAvatarDataUri（room_info 时装）。
-function makeUserAvatar(className) {
-  return makeAvatarImg(userAvatarDataUri, className, userDisplayName);
-}
+// 侧栏茶客列表 + 头像 + 打分 + 「我」那一行 —— 见 ./sidebar.js。打分明细 / 用户显示名
+// 封在模块内；茶客名单仍归 renderer，sidebar 经 getGuests 取数。makeAvatar /
+// makeUserAvatar 下文喂 chat_stream。
+const sidebar = createSidebar({
+  guestsEl,
+  userNameEl,
+  userAvatarWrapEl,
+  isConnected: connection.isConnected,
+  send,
+  setStatus,
+  getGuests: () => guests,
+  showPermissionPopover: (anchor, g) => showPermissionPopover(anchor, g),
+});
 
 function setStatus(kind, text) {
   statusEl.className = `status ${kind}`;
@@ -223,21 +210,6 @@ function stickToBottom(mutate) {
   const stick = messagesEl.scrollHeight - messagesEl.scrollTop - messagesEl.clientHeight < 80;
   mutate();
   if (stick) messagesEl.scrollTop = messagesEl.scrollHeight;
-}
-
-// 头像 + 右上角 V 标的组合节点。默认 permission 直接返 img；显著 permission 用
-// .avatar-wrap 包起来让 badge 浮右上角。
-function makeAvatarWithPermission(g, avatarClassName, badgeClassName) {
-  const img = makeAvatar(g.name, avatarClassName);
-  const showBadge = g.permission && g.permission !== DEFAULT_PERMISSION;
-  if (!showBadge) return img;
-  const wrap = document.createElement("span");
-  wrap.className = "avatar-wrap";
-  wrap.appendChild(img);
-  const badge = makePermissionBadge(g.permission, badgeClassName);
-  badge.classList.add("on-avatar");
-  wrap.appendChild(badge);
-  return wrap;
 }
 
 // 权限 popover（点 sidebar 头像）—— factory 实例化在 guestSettings 之后（依赖它的 open）。
@@ -291,34 +263,7 @@ function requestReview(messageId, anchorBtn) {
 // 三个出口交互。
 const messageFilter = createMessageFilter({ messagesEl, taskState });
 
-// 打分写到 sidebar 各茶客行的 ``.guest-score`` span 上（不是主聊天区）。
-// scoresByName 没该茶客 → 清空 span（turn_end 走这条路径，统一清）。
-function applyScoresToSidebar() {
-  for (const [name, span] of scoreSpansByName) {
-    const r = scoresByName.get(name);
-    if (!r) {
-      span.textContent = "";
-      delete span.dataset.kind;
-      continue;
-    }
-    span.textContent = scoreText(r);
-    // kind=scored 走默认浅灰（数字打分），其余 kind 给 [data-kind=...] 语义色。
-    if (r.kind && r.kind !== ScoreKind.SCORED) {
-      span.dataset.kind = r.kind;
-    } else {
-      delete span.dataset.kind;
-    }
-  }
-}
-
-// turn_start / turn_end 经 envelope_router 调 —— 用打分列表（turn_end 传空）替换
-// scoresByName 并刷 sidebar。renderSidebar 切房也调一次空列表清残留。
-function applyScores(scoresList) {
-  scoresByName = new Map((scoresList ?? []).map((r) => [r.guest_name, r]));
-  applyScoresToSidebar();
-}
-
-// chat-stream 工厂 —— 在所有依赖（messagesEl / makeAvatar / stickToBottom /
+// chat-stream 工厂 —— 在所有依赖（messagesEl / sidebar 头像 / stickToBottom /
 // afterAppendMessage）都已定义之后实例化。返回的 6 个方法是 envelope 分派与
 // 连接生命周期的唯一对接面，老的 makeGuestRow / makeUserRow / inFlight Map 都封在
 // 模块内不外泄。
@@ -332,85 +277,20 @@ const {
   renderHistory,
 } = createChatStream({
   messagesEl,
-  makeAvatar,
-  makeUserAvatar,
+  makeAvatar: sidebar.makeAvatar,
+  makeUserAvatar: sidebar.makeUserAvatar,
   stickToBottom,
   afterAppendMessage: messageFilter.afterAppendMessage,
   onRequestReview: requestReview,
 });
 
-// ── 茶客列表渲染 ──────────────────────────────────────────────────
-// 茶客行：头像 / 名字（权限 anchor）+ 打分小数字 + × 请离。指派 / 圆桌入口已挪到
-// composer 底栏「指派」按钮（见 assign_popover.js），不再挂在茶客行上。
-function renderGuestRowNormal(li, g, lastGuestLock) {
-  // 头像 / 名字都是「设置权限」的 anchor —— popover 锚在头像更直观，但点名字也能开。
-  const node = makeAvatarWithPermission(g, "avatar", "permission-badge");
-  node.classList.add("permission-anchor");
-  node.title = `点击设置「${g.name}」的权限（当前 ${g.permission || DEFAULT_PERMISSION}）`;
-  node.addEventListener("click", (ev) => {
-    ev.stopPropagation();
-    if (!connection.isConnected()) return;
-    showPermissionPopover(node, g);
-  });
-  li.appendChild(node);
-  const nameBadge = makeBadge("guest-name", null, g.name);
-  nameBadge.classList.add("permission-anchor");
-  nameBadge.title = `点击设置「${g.name}」的权限（当前 ${g.permission || DEFAULT_PERMISSION}）`;
-  nameBadge.addEventListener("click", (ev) => {
-    ev.stopPropagation();
-    if (!connection.isConnected()) return;
-    showPermissionPopover(node, g);
-  });
-  li.appendChild(nameBadge);
-  if (g.isolation && g.isolation !== "room") {
-    li.appendChild(makeBadge("isolation-badge", "isolation", g.isolation));
-  }
-  // 打分小数字（turn_start 时填，turn_end 时清）。margin-left:auto 推到右侧；
-  // 空 textContent 时占位不可见，文字一来就显示，不引发布局抖动（min-width）。
-  const score = document.createElement("span");
-  score.className = "guest-score";
-  li.appendChild(score);
-  scoreSpansByName.set(g.name, score);
-  const remove = document.createElement("button");
-  remove.type = "button";
-  remove.className = "row-icon-btn row-remove";
-  remove.textContent = "×";
-  if (lastGuestLock) {
-    remove.disabled = true;
-    remove.title = "至少要保留一位茶客";
-  } else {
-    remove.title = `请离 ${g.name}`;
-    remove.addEventListener("click", () => {
-      if (!connection.isConnected()) return;
-      if (!window.confirm(`请离茶客「${g.name}」？\n房间历史不动，guests/${g.name}/ 工作目录也不会被删，但不会再参与对话。`)) return;
-      send({ type: Inbound.REMOVE_GUEST, name: g.name });
-      setStatus("", `请离 ${g.name}…`);
-    });
-  }
-  li.appendChild(remove);
-}
-
-function renderGuests() {
-  guestsEl.replaceChildren();
-  scoreSpansByName.clear();
-  // 最后一位茶客不能删（与 server 端 admin.remove_guest 硬约束一致）—— 前端禁用按钮，
-  // 用户少踩一次"提交后才发现不行"的坑。
-  const lastGuestLock = guests.length <= 1;
-  for (const g of guests) {
-    const li = document.createElement("li");
-    renderGuestRowNormal(li, g, lastGuestLock);
-    guestsEl.appendChild(li);
-  }
-}
-
 // ── sidebar 装配（room_info）────────────────────────────────────────
 
 function renderSidebar(roomInfo) {
-  // 进新房（首次连接 / 换房）的全量重置：清 in-flight 流 + 当前 turn 打分残留 + 消息
-  // 容器 + 待发文件 pills（pill 的 rel 是按房间 share/ 计的相对路径，换房后挂别房不通）。
+  // 进新房（首次连接 / 换房）的全量重置：清 in-flight 流 + 消息容器 + 待发文件 pills
+  // （pill 的 rel 是按房间 share/ 计的相对路径，换房后挂别房不通）。打分残留由下文
+  // sidebar.renderGuests 重建时清。
   clearInFlight();
-  scoresByName = new Map();
-  scoreSpansByName.clear();
   // 切房 / 重连 / 清空 → filter 视图无意义，强 exit 让新房间从全量视角起步。
   messageFilter.exitFilter();
   messagesEl.replaceChildren();
@@ -446,8 +326,6 @@ function renderSidebar(roomInfo) {
   setStatus("ok", `已连接 ${wsUrl}`);
   roomNameEl.textContent = roomInfo.room_name || "—";
   roomTopicEl.textContent = roomInfo.topic || "";
-  userDisplayName = roomInfo.user_display_name || "我";
-  userAvatarDataUri = roomInfo.user_avatar_data_uri || null;
   settings.setSnapshot({
     userMdContent: roomInfo.user_md_content,
     userMdSource: roomInfo.user_md_source,
@@ -458,11 +336,14 @@ function renderSidebar(roomInfo) {
     roomDefaultLlmModel: roomInfo.room_default_llm?.model || null,
   });
   roomSettings.setSnapshot(roomInfo);
-  renderUserRow();
+  sidebar.setUser({
+    displayName: roomInfo.user_display_name,
+    avatarDataUri: roomInfo.user_avatar_data_uri,
+  });
   guests = Array.isArray(roomInfo.guests) ? roomInfo.guests : [];
   personasAvailable = Array.isArray(roomInfo.personas_available) ? roomInfo.personas_available : [];
   maxAiTurns = roomInfo.orchestrator?.max_consecutive_ai_turns ?? 20;
-  renderGuests();
+  sidebar.renderGuests();
   // 房间列表 + P9「进行中」后台房徽标（见 ./room_list.js）—— render 内部从权威快照
   // rooms_available[].busy 重建后台房集合再渲染。
   roomList.render(roomInfo.rooms_available, roomInfo.current_room_id);
@@ -636,11 +517,6 @@ newRoomSubmitEl.addEventListener("click", () => {
 });
 
 // ── 我（USER.md / 头像）─────────────────────────────────────────────
-
-function renderUserRow() {
-  userNameEl.textContent = userDisplayName;
-  userAvatarWrapEl.replaceChildren(makeUserAvatar("user-avatar"));
-}
 
 const settings = createSettings({
   userMd: {
@@ -828,7 +704,7 @@ const envelopeRouter = createEnvelopeRouter({
   debugPanel,
   renderSidebar,
   renderHistory,
-  applyScores,
+  applyScores: sidebar.applyScores,
   turnState,
   proposalCard,
   startStreamingMessage,
@@ -1081,7 +957,7 @@ composer.addEventListener("submit", (ev) => {
   // task_id snapshot at submit —— server 端在 inbound 接帧时按当前 active 打 tag，与
   // 这里 active 通常一致（单客户端串行 inbound + 用户改 active 也走 inbound 排队）。
   appendBubble({
-    speaker: userDisplayName,
+    speaker: sidebar.getUserDisplayName(),
     text: echo,
     kind: "user",
     taskId: taskState.getActiveTask()?.id ?? null,

--- a/app/renderer/renderer.js
+++ b/app/renderer/renderer.js
@@ -24,7 +24,6 @@ import {
   TASK_UNTITLED,
   BACKGROUND_MILESTONE_TYPES,
   buildOwnerOptionData,
-  formatTaskLabel,
   formatTaskEventNotice,
   formatManagedSessionNotice,
   isTaskClosed,
@@ -58,6 +57,8 @@ import { createSplitter } from "./splitter.js";
 import { createProposalCard } from "./proposal_card.js";
 import { createComposerTaskChip } from "./composer_task_chip.js";
 import { createChatStream } from "./chat_stream.js";
+import { createMessageFilter } from "./message_filter.js";
+import { createCommands } from "./commands.js";
 
 const statusEl = document.getElementById("status");
 const messagesEl = document.getElementById("messages");
@@ -221,23 +222,6 @@ function updateNewTaskBtn() {
 const SEND_ICON = "↑";
 const STOP_ICON = "■";
 
-// ``/help`` 输出文案 —— 用 markdown 渲，居中系统气泡承载。**Web 与 CLI 两面 help 各
-// 自维护本面支持的命令**：CLI 端的 ``_HELP_LINES`` 含 ``/info`` / ``/quit``（REPL 才
-// 有意义），Web 端含 ``/task``（CLI 走 ``@<名字>`` 路径不开任务）。加 / 改命令时
-// 改本面的那份即可，不必试图 cross-runtime 同步。
-const HELP_TEXT = [
-  "**chahua 系统命令**",
-  "",
-  "- `/help` 或 `/?` —— 显示本帮助",
-  "- `/task <标题>` —— 新建任务（已有 active 时服务端会拒）",
-  "- `/clear` 或 `/new` —— 清空整间房间聊天（重置 transcript / 摘要 / 茶客会话窗口）",
-  "- `/clear task` —— 清空当前任务的全部产物（仅删 `artifacts/`，任务本身保留）",
-  "- `/tools <茶客名>` —— 查看某位茶客 agent 注册的工具",
-  "- `/skills <茶客名>` —— 查看某位茶客可用的 skills",
-  "",
-  "_本帮助是本地提示，不进 transcript；刷新 / 切房后消失。_",
-].join("\n");
-
 // GUEST_CAPS_INFO envelope → system 气泡文案。view 决定列 tools 还是 skills 段
 // （permission / guest 两段共用）。description 取首行 + 截断，避免长描述刷屏。
 function formatGuestCaps(data, view) {
@@ -335,123 +319,10 @@ function requestReview(messageId, anchorBtn) {
   })));
 }
 
-// ── 消息上的任务 chip + filter 视图（P5.2.10）─────────────────────────────
-//
-// chip 状态随 taskState 变 —— task_panel 没把消息 chip 文案当模块状态存（DOM 即真
-// 源），refresh 是幂等的"看一眼 taskState、按需改 chip"。新挂的 li 直接调一次
-// afterAppendMessage 而不是等 subscriber 全局 walk（walk N 条消息比单挂贵）。
-
-let _filterTaskId = null;
-let _filterBannerEl = null;
-
-function getLiTaskId(li) {
-  return li.dataset.taskId || null;
-}
-
-function refreshMessageTaskChip(li) {
-  const taskId = getLiTaskId(li);
-  let chip = li.querySelector(".message-task-chip");
-  const removeChip = () => { if (chip) { chip.remove(); chip = null; } };
-  if (!taskId) {
-    removeChip();
-    return;
-  }
-  const activeId = taskState.getState().activeTaskId;
-  // active 任务的消息不挂 chip —— 默认 chat 主流就是 active，挂了反而吵。
-  if (taskId === activeId) {
-    removeChip();
-    return;
-  }
-  // task 还没加载（room_history 先于 task_info）/ 被删了 —— 不挂；下次 subscriber 补。
-  const task = taskState.getTaskById(taskId);
-  if (!task) {
-    removeChip();
-    return;
-  }
-  const text = formatTaskLabel(task);
-  if (chip) {
-    if (chip.textContent !== text) chip.textContent = text;
-    return;
-  }
-  chip = document.createElement("button");
-  chip.type = "button";
-  chip.className = "message-task-chip";
-  chip.textContent = text;
-  chip.title = `进入任务「${task.title || TASK_UNTITLED}」的 filter 视图`;
-  chip.addEventListener("click", (ev) => {
-    ev.stopPropagation();
-    enterMessageFilter(taskId);
-  });
-  const bubble = li.querySelector(".bubble");
-  if (bubble) bubble.appendChild(chip);
-}
-
-function refreshAllMessageTaskChips() {
-  for (const li of messagesEl.querySelectorAll("li[data-task-id]")) {
-    refreshMessageTaskChip(li);
-  }
-}
-
-function applyMessageFilterTo(li) {
-  if (_filterTaskId === null) {
-    li.classList.remove("filtered-out");
-    return;
-  }
-  li.classList.toggle("filtered-out", getLiTaskId(li) !== _filterTaskId);
-}
-
-function applyMessageFilterAll() {
-  for (const li of messagesEl.querySelectorAll("li")) applyMessageFilterTo(li);
-}
-
-// 三处 append 调用站（appendBubble / startStreamingMessage / endStreamingMessage 的
-// 无 start 分支）的尾部都做一样的事 —— 刷 chip + 应用 filter。单出口，将来加 third
-// concern（搜索高亮 / 已读标记等）也只动这里。
-function afterAppendMessage(li) {
-  refreshMessageTaskChip(li);
-  applyMessageFilterTo(li);
-}
-
-function enterMessageFilter(taskId) {
-  _filterTaskId = taskId;
-  ensureFilterBanner();
-  updateFilterBannerText();
-  _filterBannerEl.hidden = false;
-  applyMessageFilterAll();
-}
-
-function exitMessageFilter() {
-  if (_filterTaskId === null) return;
-  _filterTaskId = null;
-  if (_filterBannerEl) _filterBannerEl.hidden = true;
-  applyMessageFilterAll();
-}
-
-function ensureFilterBanner() {
-  if (_filterBannerEl) return;
-  _filterBannerEl = document.createElement("div");
-  _filterBannerEl.className = "message-filter-banner";
-  _filterBannerEl.hidden = true;
-  const text = document.createElement("span");
-  text.className = "message-filter-banner-text";
-  _filterBannerEl.appendChild(text);
-  const exit = document.createElement("button");
-  exit.type = "button";
-  exit.className = "message-filter-banner-exit";
-  exit.textContent = "返回全部";
-  exit.addEventListener("click", exitMessageFilter);
-  _filterBannerEl.appendChild(exit);
-  // 插到 messagesEl 紧前 —— flex 容器 #main 里同级 sibling，挡不到聊天区域滚动。
-  messagesEl.parentNode.insertBefore(_filterBannerEl, messagesEl);
-}
-
-function updateFilterBannerText() {
-  if (!_filterBannerEl || _filterTaskId === null) return;
-  const task = taskState.getTaskById(_filterTaskId);
-  const title = task ? task.title || TASK_UNTITLED : _filterTaskId;
-  _filterBannerEl.querySelector(".message-filter-banner-text").textContent =
-    `仅显示任务「${title}」的消息 —— 其余隐起来`;
-}
+// 消息上的任务 chip + filter 视图（P5.2.10）—— 见 ./message_filter.js。filter 状态
+// 全封在模块内，renderer 只通过 afterAppendMessage / exitFilter / onTaskStateChange
+// 三个出口交互。
+const messageFilter = createMessageFilter({ messagesEl, taskState });
 
 // 打分写到 sidebar 各茶客行的 ``.guest-score`` span 上（不是主聊天区）。
 // scoresByName 没该茶客 → 清空 span（turn_end 走这条路径，统一清）。
@@ -490,7 +361,7 @@ const {
   makeAvatar,
   makeUserAvatar,
   stickToBottom,
-  afterAppendMessage,
+  afterAppendMessage: messageFilter.afterAppendMessage,
   onRequestReview: requestReview,
 });
 
@@ -567,7 +438,7 @@ function renderSidebar(roomInfo) {
   scoresByName = new Map();
   scoreSpansByName.clear();
   // 切房 / 重连 / 清空 → filter 视图无意义，强 exit 让新房间从全量视角起步。
-  exitMessageFilter();
+  messageFilter.exitFilter();
   messagesEl.replaceChildren();
   upload.clear();
   // propose 卡片去重指纹也按房间边界清 —— 否则跨房间同 proposer/kind/payload 会被错误折叠。
@@ -1359,12 +1230,8 @@ createSplitter(
 // 丢失时仍 disable，防止悄悄允许开第二个（docs §7.1 实现项第 4 条）。
 //
 // 任务房间消息 chip + filter banner 文案也跟着 taskState 走 —— 任务改名 / 切 active /
-// 关任务都靠这条 subscriber 顺着重刷。filter banner 自身的可见性由 enter / exit 控制；
-// 这里只刷文案。
-taskState.subscribe(() => {
-  refreshAllMessageTaskChips();
-  if (_filterTaskId !== null) updateFilterBannerText();
-});
+// 关任务都靠这条 subscriber 顺着重刷（见 ./message_filter.js）。
+taskState.subscribe(messageFilter.onTaskStateChange);
 
 taskState.subscribe((state) => {
   const active = taskState.getActiveTask();
@@ -1523,6 +1390,22 @@ roomNameEl.addEventListener("dblclick", (ev) => {
   showRoomActionsPopover(roomNameEl);
 });
 
+// 斜杠命令处理器 —— composer submit 时 tryHandle(text) 优先拦截。clearInput 复刻
+// 原内联的"清空 textarea + 重算高度"两步。
+const commands = createCommands({
+  isConnected: () => connected,
+  send,
+  setStatus,
+  appendBubble,
+  taskState,
+  upload,
+  clearRoom: clearCurrentRoom,
+  clearInput: () => {
+    textInput.value = "";
+    autoResizeTextarea();
+  },
+});
+
 composer.addEventListener("submit", (ev) => {
   ev.preventDefault();
   if (!dropdownEl.hidden) {
@@ -1544,92 +1427,9 @@ composer.addEventListener("submit", (ev) => {
     return;
   }
   const text = textInput.value.trim();
-  // /help（或 /?）—— 在聊天区里以系统气泡显示可用斜杠命令清单。本地 UI 行为，不
-  // 走 server 帧、不进 transcript；刷新 / 切房 / clear 都会消失。
-  if (text === "/help" || text === "/?") {
-    appendBubble({ kind: "system", text: HELP_TEXT });
-    textInput.value = "";
-    autoResizeTextarea();
-    return;
-  }
-  // /tools <茶客名> / /skills <茶客名> —— 查某位茶客 agent 的 tools / 可用 skills。
-  // 两者走同一只读 inbound list_guest_caps；view 随帧发出、回包原样带回，前端按它
-  // 裁剪显示哪段（不靠全局态，多查询并发不串台）。本地查询，不进 transcript。
-  {
-    const isTools = text === "/tools" || text.startsWith("/tools ");
-    const isSkills = text === "/skills" || text.startsWith("/skills ");
-    if (isTools || isSkills) {
-      const cmd = isTools ? "/tools" : "/skills";
-      const guest = text.slice(cmd.length).trim();
-      if (!guest) {
-        setStatus("error", `${cmd} 后面要跟茶客名`);
-        return;
-      }
-      if (!connected) {
-        setStatus("error", "未连接服务端");
-        return;
-      }
-      send({
-        type: Inbound.LIST_GUEST_CAPS,
-        guest,
-        view: isTools ? "tools" : "skills",
-      });
-      textInput.value = "";
-      autoResizeTextarea();
-      return;
-    }
-  }
-  // 斜杠命令 —— /task <title> 走 open_task inbound 而非 user_message。已有任务等
-  // server 端拒绝（NOTICE error），前端不重复判定，让两条路径决断口径完全同源。
-  if (text.startsWith("/task ") || text === "/task") {
-    const title = text.slice("/task".length).trim();
-    if (!title) {
-      setStatus("error", "/task 后面要跟任务标题");
-      return;
-    }
-    if (upload.hasPending()) {
-      setStatus("error", "新建任务前先 × 掉待发文件 —— 任务不接附件");
-      return;
-    }
-    send({ type: Inbound.OPEN_TASK, title, goal: "", owner: null });
-    setStatus("", `新建任务「${title}」…`);
-    textInput.value = "";
-    autoResizeTextarea();
-    return;
-  }
-  // /clear task：清空当前 active 任务的全部产物（仅删 artifacts/，任务本身保留）。
-  // 必须排在 /clear / /new 之前 —— 否则 startsWith 边界让 "/clear task" 被前缀吞掉。
-  if (text === "/clear task" || text === "/clear-task") {
-    const active = taskState.getActiveTask();
-    if (!active) {
-      setStatus("error", "/clear task 需要先选中一个任务");
-      return;
-    }
-    const count = Array.isArray(active.artifacts) ? active.artifacts.length : 0;
-    if (count === 0) {
-      setStatus("", `任务「${active.title}」没有产物`);
-      textInput.value = "";
-      autoResizeTextarea();
-      return;
-    }
-    if (!window.confirm(
-      `确定清空任务「${active.title}」的全部产物（${count} 个文件）？\n任务本身（决策 / 状态 / 摘要）保留，仅删 artifacts/ 下的文件。`,
-    )) return;
-    send({ type: Inbound.CLEAR_TASK_ARTIFACTS, task_id: active.id });
-    setStatus("", `清空任务「${active.title}」的产物…`);
-    textInput.value = "";
-    autoResizeTextarea();
-    return;
-  }
-  // /clear 与 /new：键盘快捷的"清空聊天"，与房间菜单同入口共用 confirm —— 滑指误打
-  // /task 边界（如想 /task 打成 /clear）有 confirm 兜底；clearCurrentRoom 内部不连接
-  // 时 noop，所以此处不再判 connected。
-  if (text === "/clear" || text === "/new") {
-    textInput.value = "";
-    autoResizeTextarea();
-    clearCurrentRoom();
-    return;
-  }
+  // 斜杠命令（/help /tools /skills /task /clear task /clear /new）—— 见 ./commands.js。
+  // 命中即在模块内执行并返回 true，普通发送路径不再走。
+  if (commands.tryHandle(text)) return;
   // 文件不空时即使 text 为空也允许发送 —— 用户拖了文件就是有意图。
   if (!text && !upload.hasPending()) return;
   const files = upload.snapshotRels();

--- a/app/renderer/room_list.js
+++ b/app/renderer/room_list.js
@@ -1,0 +1,119 @@
+"use strict";
+
+// 侧栏房间列表 + P9「进行中」后台房徽标。从 renderer.js 抽出（renderer 重构）。
+//
+// 「进行中」后台房集合（backgroundActiveRooms）全封进模块 —— renderer 只经 render
+// （room_info 来时按权威快照重建 + 渲染）/ onBackgroundMilestone（后台里程碑事件增量
+// 维护）两个出口交互。后台房集合按 envelope room_id（= room.name）键。
+
+import { EventType, Inbound } from "./events.js";
+
+export function createRoomList({ roomsEl, isConnected, send, setStatus }) {
+  // P9：当前判定「进行中」的后台房间 envelope room_id 集合。后台里程碑事件 add、
+  // room_background_finished remove；refreshRoomBadges 据此渲染列表「进行中」徽标。
+  const backgroundActiveRooms = new Set();
+
+  // 切换房间列表 —— 列其它房间（含当前），click 非 current 项发 switch_room frame。
+  // 当前房间高亮、不可点；其它房间显示 name + topic 一句话预览，hover 出现"删除"按钮。
+  function renderRoomsList(roomsAvailable, currentRoomId) {
+    roomsEl.replaceChildren();
+    const rooms = Array.isArray(roomsAvailable) ? roomsAvailable : [];
+    for (const r of rooms) {
+      const li = document.createElement("li");
+      li.dataset.roomId = r.room_id;
+      // P9：后台房徽标按 envelope room_id（= room.name）匹配 —— 存 r.name 供
+      // refreshRoomBadges 查（envelope 顶层 room_id 用 room.name，不是目录名）。
+      li.dataset.roomName = r.name || r.room_id;
+      if (r.room_id === currentRoomId) li.classList.add("current");
+      // text 块外裹 .room-meta，方便 row-remove 用 margin-left:auto 推到右侧。
+      const meta = document.createElement("div");
+      meta.className = "room-meta";
+      const name = document.createElement("div");
+      name.className = "room-name";
+      name.textContent = r.name || r.room_id;
+      meta.appendChild(name);
+      if (r.topic) {
+        const topic = document.createElement("div");
+        topic.className = "room-topic";
+        topic.textContent = r.topic;
+        meta.appendChild(topic);
+      }
+      li.appendChild(meta);
+      if (r.room_id !== currentRoomId) {
+        li.addEventListener("click", () => {
+          if (!isConnected()) return;
+          send({ type: Inbound.SWITCH_ROOM, room_id: r.room_id });
+          setStatus("", `切换到 ${r.name || r.room_id}…`);
+        });
+        // 删除房间按钮 —— 只对非当前房显示。当前房不能删（先切走再删，与 server 端约束一致）。
+        const remove = document.createElement("button");
+        remove.type = "button";
+        remove.className = "row-icon-btn row-remove";
+        remove.textContent = "×";
+        remove.title = `删除房间 ${r.name || r.room_id}`;
+        remove.addEventListener("click", (ev) => {
+          ev.stopPropagation();
+          if (!isConnected()) return;
+          if (!window.confirm(`删除房间「${r.name || r.room_id}」？\n房间目录及其全部历史 / 摘要 / 茶客工作区会被永久删除，无法撤销。`)) return;
+          send({ type: Inbound.DELETE_ROOM, room_id: r.room_id });
+          setStatus("", `删除 ${r.name || r.room_id}…`);
+        });
+        li.appendChild(remove);
+      }
+      roomsEl.appendChild(li);
+    }
+    refreshRoomBadges();
+  }
+
+  // P9：按 backgroundActiveRooms 集合刷新房间列表「进行中」徽标 —— 不重建整个列表
+  // （避免后台事件高频到达时房间列表闪烁）。徽标只挂非当前房；当前房自身活动由聊天区
+  // 体现。徽标元素增量挂 / 摘，不动其余 DOM。
+  function refreshRoomBadges() {
+    // [...children] 快照 —— 当前循环只改 li 内的徽标 span、不增删 li，但 children 是
+    // live HTMLCollection，快照后即便将来改成增删 li 也不会漏元素。
+    for (const li of [...roomsEl.children]) {
+      const active =
+        !li.classList.contains("current") &&
+        backgroundActiveRooms.has(li.dataset.roomName);
+      let badge = li.querySelector(".room-busy-badge");
+      if (active && !badge) {
+        badge = document.createElement("span");
+        badge.className = "room-busy-badge";
+        badge.textContent = "进行中";
+        badge.title = "该房间正在后台续跑";
+        li.querySelector(".room-name")?.appendChild(badge);
+      } else if (!active && badge) {
+        badge.remove();
+      }
+    }
+  }
+
+  return {
+    // room_info 来时：从权威快照 rooms_available[].busy 重建「进行中」后台房集合
+    // （切房 / 重连后这帧是真理源 —— 剔除已结束的、补上切走后转后台的；当前房不计），
+    // 再渲染房间列表。随后到的后台里程碑事件经 onBackgroundMilestone 增量维护。
+    render(roomsAvailable, currentRoomId) {
+      backgroundActiveRooms.clear();
+      for (const r of roomsAvailable ?? []) {
+        if (r.busy && r.room_id !== currentRoomId) {
+          backgroundActiveRooms.add(r.name);
+        }
+      }
+      renderRoomsList(roomsAvailable, currentRoomId);
+    },
+    // handleEnvelope 后台房间里程碑分流 —— room_background_finished = 后台 runtime
+    // 跑完自毁；其余里程碑（turn_* / message_end / task_* / managed_session_*）→
+    // 标记该房后台仍在跑。维护集合 + 刷新徽标。
+    onBackgroundMilestone(env) {
+      const roomId = env.room_id;
+      if (!roomId) return;
+      if (env.type === EventType.ROOM_BACKGROUND_FINISHED) {
+        backgroundActiveRooms.delete(roomId);
+        console.debug("[room_background_finished]", roomId);
+      } else {
+        backgroundActiveRooms.add(roomId);
+      }
+      refreshRoomBadges();
+    },
+  };
+}

--- a/app/renderer/sidebar.js
+++ b/app/renderer/sidebar.js
@@ -1,0 +1,171 @@
+"use strict";
+
+// 侧栏茶客列表 + 头像 + 打分小数字 + 「我」那一行。从 renderer.js 抽出（renderer 重构）。
+//
+// 拥有：茶客打分明细（scoresByName）+ 茶客行 → 打分 span 引用（scoreSpansByName）+
+// 用户显示名 / 头像。茶客名单（guests）仍归 renderer（被一众模块读），本模块经
+// getGuests 取数。renderer 经 makeAvatar / makeUserAvatar（喂 chat_stream）/ setUser /
+// renderGuests / applyScores / getUserDisplayName 交互。
+
+import {
+  makeAvatarImg,
+  scoreText,
+  makeBadge,
+  makePermissionBadge,
+} from "./chat_view.js";
+import { Inbound, ScoreKind, DEFAULT_PERMISSION } from "./events.js";
+
+export function createSidebar({
+  guestsEl,
+  userNameEl,
+  userAvatarWrapEl,
+  isConnected,
+  send,
+  setStatus,
+  getGuests,
+  showPermissionPopover,
+}) {
+  // 茶客行 → 打分 span 的引用。renderGuests 重建时填，applyScores 直接改文字，
+  // 不重建 DOM（避免头像 / 徽章闪烁）。
+  const scoreSpansByName = new Map();
+  // 当前 turn 的打分明细。turn_start replace / turn_end 清（经 applyScores）。
+  let scoresByName = new Map();
+  let userDisplayName = "我";
+  let userAvatarDataUri = null;
+
+  // 茶客头像 —— 按名字在 guests 数组里 find；茶客 ≤ 个位数，线性查比维护并行 Map 简单
+  // （且任何 guests 变更都自动跟上）。
+  function makeAvatar(name, className) {
+    return makeAvatarImg(
+      getGuests().find((g) => g.name === name)?.avatar_data_uri,
+      className,
+      name,
+    );
+  }
+
+  // 用户头像 —— 走 userAvatarDataUri（room_info 时装）。
+  function makeUserAvatar(className) {
+    return makeAvatarImg(userAvatarDataUri, className, userDisplayName);
+  }
+
+  // 头像 + 右上角 V 标的组合节点。默认 permission 直接返 img；显著 permission 用
+  // .avatar-wrap 包起来让 badge 浮右上角。
+  function makeAvatarWithPermission(g, avatarClassName, badgeClassName) {
+    const img = makeAvatar(g.name, avatarClassName);
+    const showBadge = g.permission && g.permission !== DEFAULT_PERMISSION;
+    if (!showBadge) return img;
+    const wrap = document.createElement("span");
+    wrap.className = "avatar-wrap";
+    wrap.appendChild(img);
+    const badge = makePermissionBadge(g.permission, badgeClassName);
+    badge.classList.add("on-avatar");
+    wrap.appendChild(badge);
+    return wrap;
+  }
+
+  // 茶客行：头像 / 名字（权限 anchor）+ 打分小数字 + × 请离。指派 / 圆桌入口已挪到
+  // composer 底栏「指派」按钮（见 assign_popover.js），不再挂在茶客行上。
+  function renderGuestRowNormal(li, g, lastGuestLock) {
+    // 头像 / 名字都是「设置权限」的 anchor —— popover 锚在头像更直观，但点名字也能开。
+    const node = makeAvatarWithPermission(g, "avatar", "permission-badge");
+    node.classList.add("permission-anchor");
+    node.title = `点击设置「${g.name}」的权限（当前 ${g.permission || DEFAULT_PERMISSION}）`;
+    node.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      if (!isConnected()) return;
+      showPermissionPopover(node, g);
+    });
+    li.appendChild(node);
+    const nameBadge = makeBadge("guest-name", null, g.name);
+    nameBadge.classList.add("permission-anchor");
+    nameBadge.title = `点击设置「${g.name}」的权限（当前 ${g.permission || DEFAULT_PERMISSION}）`;
+    nameBadge.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      if (!isConnected()) return;
+      showPermissionPopover(node, g);
+    });
+    li.appendChild(nameBadge);
+    if (g.isolation && g.isolation !== "room") {
+      li.appendChild(makeBadge("isolation-badge", "isolation", g.isolation));
+    }
+    // 打分小数字（turn_start 时填，turn_end 时清）。margin-left:auto 推到右侧；
+    // 空 textContent 时占位不可见，文字一来就显示，不引发布局抖动（min-width）。
+    const score = document.createElement("span");
+    score.className = "guest-score";
+    li.appendChild(score);
+    scoreSpansByName.set(g.name, score);
+    const remove = document.createElement("button");
+    remove.type = "button";
+    remove.className = "row-icon-btn row-remove";
+    remove.textContent = "×";
+    if (lastGuestLock) {
+      remove.disabled = true;
+      remove.title = "至少要保留一位茶客";
+    } else {
+      remove.title = `请离 ${g.name}`;
+      remove.addEventListener("click", () => {
+        if (!isConnected()) return;
+        if (!window.confirm(`请离茶客「${g.name}」？\n房间历史不动，guests/${g.name}/ 工作目录也不会被删，但不会再参与对话。`)) return;
+        send({ type: Inbound.REMOVE_GUEST, name: g.name });
+        setStatus("", `请离 ${g.name}…`);
+      });
+    }
+    li.appendChild(remove);
+  }
+
+  // 打分写到 sidebar 各茶客行的 ``.guest-score`` span 上（不是主聊天区）。
+  // scoresByName 没该茶客 → 清空 span（turn_end 走这条路径，统一清）。
+  function applyScoresToSidebar() {
+    for (const [name, span] of scoreSpansByName) {
+      const r = scoresByName.get(name);
+      if (!r) {
+        span.textContent = "";
+        delete span.dataset.kind;
+        continue;
+      }
+      span.textContent = scoreText(r);
+      // kind=scored 走默认浅灰（数字打分），其余 kind 给 [data-kind=...] 语义色。
+      if (r.kind && r.kind !== ScoreKind.SCORED) {
+        span.dataset.kind = r.kind;
+      } else {
+        delete span.dataset.kind;
+      }
+    }
+  }
+
+  return {
+    // chat_stream 渲染气泡头像用。
+    makeAvatar,
+    makeUserAvatar,
+    // submit echo 的 speaker 名。
+    getUserDisplayName: () => userDisplayName,
+    // room_info：装用户显示名 / 头像 + 重渲「我」那一行。
+    setUser({ displayName, avatarDataUri }) {
+      userDisplayName = displayName || "我";
+      userAvatarDataUri = avatarDataUri || null;
+      userNameEl.textContent = userDisplayName;
+      userAvatarWrapEl.replaceChildren(makeUserAvatar("user-avatar"));
+    },
+    // room_info：全量重渲茶客列表（getGuests 取最新名单）。打分残留同时清。
+    renderGuests() {
+      guestsEl.replaceChildren();
+      scoreSpansByName.clear();
+      scoresByName = new Map();
+      // 最后一位茶客不能删（与 server 端 admin.remove_guest 硬约束一致）—— 前端禁用
+      // 按钮，用户少踩一次"提交后才发现不行"的坑。
+      const guests = getGuests();
+      const lastGuestLock = guests.length <= 1;
+      for (const g of guests) {
+        const li = document.createElement("li");
+        renderGuestRowNormal(li, g, lastGuestLock);
+        guestsEl.appendChild(li);
+      }
+    },
+    // turn_start / turn_end 经 envelope_router 调 —— 用打分列表（turn_end 传空）
+    // 替换 scoresByName 并刷 sidebar。
+    applyScores(scoresList) {
+      scoresByName = new Map((scoresList ?? []).map((r) => [r.guest_name, r]));
+      applyScoresToSidebar();
+    },
+  };
+}

--- a/app/renderer/turn_state.js
+++ b/app/renderer/turn_state.js
@@ -1,0 +1,51 @@
+"use strict";
+
+// 当前 turn 状态 + 发送/停止按钮。从 renderer.js 抽出（renderer 重构）。
+//
+// P3.3 cancel 状态机：turn_start 时 set、turn_end(next=user) 或 status=cancelled 时
+// clear；turn_end(next=ai) 不 clear（下个 turn_start 会刷新）。currentTurnId 非空即
+// "AI 链在跑" —— submit button 切到「停止」语义，submit handler 路由到 cancel 帧。
+// currentTurnId 全封进模块，外部只经 isActive / turnId / set / clear / syncToRoom 交互。
+
+export function createTurnState({ submitBtn }) {
+  // P9：切到一个后台正在跑 turn 的房间时，前端没有那个 turn 的真实 id（turn_start 在
+  // 切房前就发过了）。用这个哨兵占位让「停止」按钮正确显示 —— render 只看 currentTurnId
+  // 是否非空、cancel 帧服务端只认 type 不校验 turn_id。真实 turn_start 到达会覆盖它。
+  const FOREGROUND_BUSY_TURN_PLACEHOLDER = "turn_foreground_busy";
+  // 同一个按钮承担「发送 / 停止」双重职责；aria-label 同步切，屏读器读"发送"/"停止"
+  // 而不是裸符号。颜色由 .stop 类 + style.css 控制。
+  const SEND_ICON = "↑";
+  const STOP_ICON = "■";
+
+  let currentTurnId = null;
+
+  function render() {
+    const busy = currentTurnId !== null;
+    submitBtn.textContent = busy ? STOP_ICON : SEND_ICON;
+    submitBtn.setAttribute("aria-label", busy ? "停止" : "发送");
+    submitBtn.title = busy ? "停止当前轮次" : "发送 (Enter)";
+    submitBtn.classList.toggle("stop", busy);
+  }
+
+  return {
+    isActive: () => currentTurnId !== null,
+    turnId: () => currentTurnId,
+    // turn_start：记下真实 turn id。
+    set(turnId) {
+      currentTurnId = turnId;
+      render();
+    },
+    // turn_end(next=user) / cancelled / 断线：清空 → 按钮复原「发送」。
+    clear() {
+      currentTurnId = null;
+      render();
+    },
+    // renderSidebar 切房：按新前台房的 busy 快照决定占位 or 清。从忙房切到闲房 →
+    // 复原「发送」；切进一个后台仍在跑的房 → 维持「停止」（哨兵占位，真实
+    // turn_start/turn_end 后续会校准）。
+    syncToRoom(busy) {
+      currentTurnId = busy ? FOREGROUND_BUSY_TURN_PLACEHOLDER : null;
+      render();
+    },
+  };
+}


### PR DESCRIPTION
## 重构 renderer.js —— god file 拆成 8 个单一职责模块

`app/renderer/renderer.js` 原 1671 行，混了 WebSocket 连接、envelope 总分派、侧栏渲染、7 个 modal、消息过滤、命令解析等 6+ 类职责。按既有「一功能一模块」工厂模式分 7 个阶段拆分。

### 抽出的模块
| 模块 | 行数 | 职责 |
|---|---|---|
| `turn_state.js` | 51 | 当前 turn 状态 + 发送/停止按钮 |
| `connection.js` | 84 | WebSocket 连接 + 重连退避 |
| `room_list.js` | 119 | 侧栏房间列表 + P9 后台房徽标 |
| `commands.js` | 121 | 斜杠命令解析（/help /tools /task …） |
| `message_filter.js` | 136 | 消息任务 chip + filter 视图 |
| `modals.js` | 169 | 添加茶客 / 新建房间 / 新任务 / 导入 persona |
| `sidebar.js` | 171 | 茶客列表 + 头像 + 打分 + 「我」行 |
| `envelope_router.js` | 268 | ws 下行 envelope 总分派 |

### 要点
- 每个模块把一组内聚逻辑**连同其私有状态**整体封装 —— `foregroundRoomId` / `backgroundActiveRooms` / `currentTurnId` / `ws` / `scoresByName` / `_filterTaskId` 等不再是 renderer 散落的 `let`。
- 模块间走既有工厂 + 回调注入模式；`taskState` / `handoffState` 单例由各模块直接 import 共享。
- **行为零变化** —— 每次抽出都是内聚逻辑的逐字搬迁，9 个文件全部 `node --check` 通过。
- `renderer.js` 1671 → 847 行（−824，−49%）。剩余部分是名副其实的装配入口：导入 + DOM 引用 + 18 个 feature 工厂实例化 + 房间装配编排 + 顶层事件接线。

### 验证
前端无自动化测试，`node --check` 全过。**建议合并前在 Electron 里手动冒烟**：连接 / 切房 / 发消息 / 斜杠命令 / 建任务 / 各 modal / 后台房徽标。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
