### PR TITLE
v0.1.3 release prep —— 版本号去 dev + CHANGELOG + 发布说明

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-05-23
+
+详见 [`docs/releases/v0.1.3.md`](docs/releases/v0.1.3.md)。
+
+### Added
+- **P9 切房后房间后台续跑**（2026-05-23，详见 [`docs/P9-切房后房间后台续跑.md`](docs/P9-切房后房间后台续跑.md)）：把「切房 = cancel + drain」的硬中断升级成「busy 的旧前台转后台续跑、新前台立即可用」。新建 `chahua/room_runtime.py` —— `RoomRuntime` dataclass（挂 session / router / in-flight 槽 / `background_since_ms`）+ `RoomEventRouter`（per-room 可变路由 sink，`mode=foreground` 全量透传 / `mode=background` 按精确白名单过滤）。server 从「持 1 个 `self._session`」升级为「持 `self._runtimes: dict[room_id, RoomRuntime]` 注册表 + `self._foreground_id` 前台指针」；in-flight 槽下沉 `RoomRuntime`，server 保留同名 compat property / wrapper（旧读点 / 测试夹具不动）。`_switch_room` 两阶段失败原子性：阶段一准备目标 runtime（任何失败「未碰旧前台」就 `return`）→ 阶段二 demote 旧前台（busy → 后台续跑、idle → close 移出）→ 切前台指针 → 重发快照；后台 turn / handoff drain 跑完即自毁（emit `room_background_finished` + close + 移出注册表）。`emit_room_snapshot` 重建 in-flight 状态（补发 `message_start` + `partial_text` delta）+ MTS 快照 + 房间列表 `busy` 标志。后台精确白名单 `_BACKGROUND_WHITELIST` 收敛到里程碑事件（`turn_*` / `message_end` / `task_info` / `task_artifact_added` / `managed_session_*` / `room_background_finished`），高频流式一律丢弃。global 茶客切走前必 `cancel+drain`（共享 cwd 软链与目标房 retarget 撞车）。前端按 `envelope.room_id`（即 `room.name`）分流前台 / 后台房间里程碑——故 `[room].name` 跨房唯一成为承重契约，`admin.create_room` / `admin.update_room_toml` 两入口拒重名。
+  - **P9.4 后台房间软上限**。`server.py` 加 `MAX_BACKGROUND_ROOMS = 5` 模块常量；`_inbound_switch_room` 在 `_switch_room` 之后调 `_enforce_background_room_limit`，后台 runtime 数超上限即淘汰 `background_since_ms` 最小（最早转入后台）者——走强制拆除路径 `_aclose_one_runtime`（带 MTS 先 `end_managed_session` 再 cancel drain），拆除**之后**补一帧 `room_background_finished` + emit info `NOTICE`（前后顺序避免「进行中」徽标闪烁）。**软上限**：超限淘汰最早项、不拒绝切房。
+- **P10 聊天界面增强 —— Mermaid / 图片预览 / 产物下载链**（2026-05-23，详见 [`docs/P10-聊天界面增强.md`](docs/P10-聊天界面增强.md)）：把聊天气泡从「纯文本框」升级成「会渲染、会展示产物的载体」。**纯前端 + 协议薄增量**：后端只新增「消息 → 产物」一张落盘表 + envelope 多一个可选字段 `originated_message_id`，不改对话原语 / Task 数据结构 / 不 bump `schema_version`。
+  - **后端 message ↔ artifact 关联**。新建 `chahua/message_artifacts.py`（`MessageArtifactRegistry` + `ArtifactRef`）—— per-room 落 `rooms/<id>/message_artifacts.jsonl`、与 `transcript.jsonl` 同生命周期；`reset_room` 同步 clear。`transport_bridge` 在写盘工具命中时 `record_pending(rel → message_id)`；`ArtifactDetector.detect` 在 pick 周期末 `consume_pending` 取出 + 持久化 + emit envelope 多挂 `originated_message_id`。`emit_room_history` 按 message_id 投影 `originated_artifacts`，刷新 / 切房 / 重启后历史挂件还原。加载严格 `isinstance(str)` 校验 mid/name + 显式拒 bool size + rel 必落 `share/` 或 `tasks/<id>/artifacts/` 已知 root（两 root 都做空段 / `.` / `..` segment 校验）。
+  - **shell / MCP 工具走前后 diff 回填 pending**。`task_write_artifact` / `write_file` / `replace` 三个 args-known 写盘工具直接走 `_maybe_record_artifact_path`；shell / MCP 类 args-unknown 工具靠两次扫盘 diff 回填，`_tool_call_snapshots` entry 捕获 message_id / task_id 让晚到 TOOL_COMPLETE 仍能正确归属。滚动 baseline（`self._diff_baseline`）压「每个工具调用扫两次」成「首次扫一次 + 每个 COMPLETE 扫一次」；bind 退出清 baseline，跨 speak 不共享；晚到 TOOL_COMPLETE（bind 已退）不再回填 baseline（防下次 bind 首扫被跳过）。
+  - **`download_file.purpose` 分流**。inbound 可选 `purpose ∈ {download, preview}`（默认 download），envelope `file_download` 原样回声；server 行为对取值无差异，前端按 `purpose === "preview"` 单分支判断。失败路径 `_fail_download` 同步带 purpose（preview 路径的「图占位失败」塞 `<img>.alt` 不弹下载 alert）。
+  - **前端 Mermaid 渲染**。`mermaid ^11.15.0` 依赖；`chat_view.js::renderMermaidIn` 动态 import 懒加载 + SVG 手工 sanitize（DOMPurify 对 `<foreignObject>` 强制清空内容，mermaid v11 节点 label 走 `<foreignObject>+HTML` 会被剥光）；流式 delta 期间禁调，入口收敛于 `renderGuestText` / `endStreamingMessage` ok 终态 / `task_panel` goal。失败保留原 `<pre>` + `.mermaid-error` class + CSS 红边。
+  - **前端 artifact 挂件**。`chat_view.js::attachArtifactToBubble` / `resolveArtifactPreview` / `clearPendingArtifactPreviews`。图片白名单 `{png, jpg, jpeg, gif, webp}` 走内嵌 `<img>` 懒预览（占位 + `download_file purpose=preview` 拉字节 + 一次性灌所有等待者）；SVG / 其它扩展走 pill 下载链（`<a class="artifact-pill">`）。挂件按 `[data-rel]` 去重防 live + history 双触发。`renderSidebar` 切房路径调 `clearPendingArtifactPreviews()` —— 防 `messagesEl.replaceChildren` 后 pending Map 持续涨内存泄露。`envelope_router.js::TASK_ARTIFACT_ADDED` 拆挂件 vs 系统气泡兜底；`FILE_DOWNLOAD` 按 `purpose` 分流。
+- **`renderer.js` 模块化重构**（2026-05-22）：从 ~1500 行单文件拆成 8 个职责单一子模块（PR #8 合 7 次提交）—— `message_filter`（系统气泡过滤）/ `commands`（slash 命令注册表）/ `connection`（ws 连接管理）/ `room_list`（房间列表渲染）/ `turn_state`（turn 状态机）/ `envelope_router`（envelope 分派）/ `sidebar`（侧栏渲染）/ `modals`（模态框）。
+- **`debug_panel.js` 模块化重构**（2026-05-22）：拆出纯工具模块（`debug_panel_utils.js`）与渲染树模块（`debug_panel_tree.js`），整文件从单一巨函数收敛成分层数据流。
+- **Yvonne 角色加 `create_image` skill**（2026-05-23）：按用户提示词直接生成图像，封装四种生图后端（`gpt` / `nanobanana` / `seedreamv5` / `wan`）由 `--model` 选择；支持画幅 / 质量 / 出图张数；不强制输出位置、agent 据上下文选目标目录。persona-bundled skill，零后端改动。
+
 ## [0.1.2] - 2026-05-21
 
 详见 [`docs/releases/v0.1.2.md`](docs/releases/v0.1.2.md)。

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.3-dev",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.3-dev",
+      "version": "0.1.3",
       "dependencies": {
         "dompurify": "^3.4.3",
         "marked": "^18.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.3-dev",
+  "version": "0.1.3",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.3.dev0"
+__version__ = "0.1.3"

--- a/docs/releases/v0.1.3.md
+++ b/docs/releases/v0.1.3.md
@@ -1,0 +1,57 @@
+# v0.1.3 —— 切房后房间后台续跑 + 聊天界面增强（2026-05-23）
+
+继 v0.1.2「显式 handoff + 任务管理与原生自动推进」之后第四个版本。本版分两条主线：① **P9 切房后房间后台续跑** —— 把「切房 = cancel + drain」的硬中断升级成「busy 的旧前台转后台续跑、新前台立即可用」，让用户能在一个 ws 连接里并发跑多个房间的工作流（含 P9.4 软上限 5 间淘汰最早后台房）；② **P10 聊天界面增强** —— 把聊天气泡从「纯文本框」升级成「会渲染、会展示产物的载体」（茶客 markdown 内 ` ```mermaid ` 代码块懒加载渲染成 SVG / `task_write_artifact` 产出图片在气泡末尾内嵌预览 / 其它扩展挂可点下载的 pill）。期间还做了 `renderer.js` / `debug_panel.js` 的模块化重构，把前端最大两个文件拆成 9 个职责单一的子模块。999 测试全过（v0.1.2 收线 860 → +139）。
+
+## 亮点
+
+- **切房后房间不再硬中断**：以前切走一个跑着 turn / handoff 的房间会立刻 cancel + drain（茶客发到一半的话截在那）；现在旧前台 busy 时自动转后台续跑，新前台立即可用，可同时跑多个房间。切回时 `emit_room_snapshot` 重建 in-flight 状态（补发 `message_start` + `partial_text` delta），完整无损。
+- **后台房间软上限 + 进行中徽标**：`MAX_BACKGROUND_ROOMS = 5` 软上限，超限淘汰最早转入后台的那个（不拒切房）；房间列表「⏳ 进行中」徽标在后台房保持点亮，回切时自动灭。
+- **气泡内 Mermaid 图渲染**：茶客发言里的 ` ```mermaid graph TD; A --> B ``` ` 代码块在 `message_end` 全文到位时自动渲染成 SVG，流式期间显示源码不闪烁；mermaid 库走动态 import 懒加载。
+- **气泡末尾内嵌图片预览 + 下载 pill**：茶客通过 `task_write_artifact` 产出的图片在产生它的那条气泡末尾内嵌缩略图（懒拉字节、点击下载），其它扩展（含 SVG）挂带文件名 + 大小的下载 pill 按钮；切房 / 刷新后历史挂件按 `originated_artifacts` 还原。
+- **前端模块化重构**：`renderer.js` 拆成 7 个职责单一子模块（message_filter / commands / connection / room_list / turn_state / envelope_router / sidebar / modals），`debug_panel.js` 拆成纯工具 + 渲染树两个模块。
+
+## 里程碑（按提交序）
+
+- **electron-builder artifactName ASCII 化**（提交 80dd610，合并到 main）：把打包产物名从中文「茶话室-…」改成 `chahua-<ver>-mac-arm64.dmg`，给 `gh release create` 上传时少踩 Unicode 编码坑。
+- **P9 切房后房间后台续跑**（设计文档 + 实现 + Codex review 修，13 次提交）：
+  - **9.1 骨架**：新建 `chahua/room_runtime.py`（`RoomRuntime` dataclass，挂 session / router / in-flight 槽 / `background_since_ms` 时间戳）+ `RoomEventRouter`（`EnvelopeSink` 子类，per-room 可变路由 sink；`mode = foreground` 全量透传、`mode = background` 按精确白名单 `_BACKGROUND_WHITELIST` 过滤）。server 从「持 1 个 `self._session`」升级为「持 `self._runtimes: dict[room_id, RoomRuntime]` 注册表 + `self._foreground_id` 前台指针」；`_session` 读点统一走 `_foreground_runtime.session`；in-flight 槽（`inflight_task` / `inflight_kind`）下沉 `RoomRuntime`，server 保留同名 compat property / wrapper（旧读点 / 测试夹具不动）。
+  - **9.2 切房两阶段失败原子性**：`_switch_room` 不再 `_cancel_and_drain_inflight`。阶段一准备目标 runtime（已在注册表的后台 runtime 直接复用、不在则 `build_room_session` 装配），任何失败（目录不存在 / room.toml 坏 / LLM 凭据缺）都在「未碰旧前台」时 `return`；阶段二目标就绪后 demote 旧前台（busy → `router.mode=background` 留注册表后台续跑、idle → close 移出）→ 切 `_foreground_id` → 重发快照。后台 turn / handoff drain 跑完，`_run_turn` / `_run_handoff_turn` 的 finally 调 `_maybe_self_destruct_background_runtime`：runtime 仍 `background` 且 in-flight 槽空 → emit `room_background_finished` + close + 移出注册表（后台 runtime「仅在真有 in-flight 活时存在」）。
+  - **9.3 后台精确白名单 + 切回快照重建**：`_BACKGROUND_WHITELIST` 收敛到「里程碑事件」：`turn_start` / `turn_end` / `message_end` / `task_info` / `task_artifact_added` / `managed_session_*` / `room_background_finished`，高频流式（`message_start` / `message_delta` / `guest_thinking` / `tool_*`）一律丢弃——后台发言**内容**靠切回时 `room_history` 快照从盘重建（完整无损）。`emit_room_snapshot` 末尾对前台房补发 MTS 快照（`_managed_session` 非空 → 补一帧 `managed_session_started`）+ in-flight 消息快照（补 `message_start` + `partial_text` delta，让切回前已流出的内容立即在聊天区 / 调试面板成形）；房间列表 `rooms_available` 每房带 `busy` 标志。
+  - **`aclose()` 异步清理 + 幂等**：从同步退路改成 `async def aclose()` 对全部 runtime cancel+drain+close 三步各自 try（带 MTS 先 `end_managed_session` 再 cancel drain）；重复 cancel/close 同一 runtime 静默放过。
+  - **三处边角修**：global 茶客在切走前必 `cancel+drain`（跨房共享 cwd 软链与目标房 retarget 撞车）/ `background_since_ms` 时间戳 demote 时写、切回前台清回 `None` / 删房守卫拒删跑着 turn 的房间。
+  - **前端按 room_id 分流 + 房间列表徽标**：envelope 顶层 `room_id` 用 `room.name` 占位，前端按它分流前台 / 后台房间里程碑（同名会让后台房 envelope 污染当前前台房 —— 故 `[room].name` 跨房唯一是承重契约，`admin.create_room` / `admin.update_room_toml` 两入口都拒重名）。
+  - **Codex review 修**：调试面板补迟到工具完成（`fetch_turn_detail` 路径补补全 `TOOL_COMPLETE` 帧）+ 切回房间后当前 turn 不显示（聊天 + 调试）/ 切房后「停止」按钮卡死不复原（前台指针切换时同步重置 UI 态）。
+- **P9.4 后台房间软上限**（2 次提交）：`server.py` 加 `MAX_BACKGROUND_ROOMS = 5` 模块常量；`_inbound_switch_room` 在 `_switch_room` 之后调 `_enforce_background_room_limit`，后台 runtime 数超上限即淘汰 `background_since_ms` 最小（最早转入后台）者——走强制拆除路径 `_aclose_one_runtime`（带 MTS 先 `end_managed_session` 再 cancel drain），拆除**之后**补一帧 `room_background_finished` + emit info `NOTICE`（前后顺序避免「进行中」徽标闪烁）。**软上限**：超限淘汰最早项、不拒绝切房。
+- **`renderer.js` 模块化重构**（7 次提交，PR #8）：从 ~1500 行单文件拆成 8 个职责单一子模块——`message_filter`（系统气泡过滤）/ `commands`（slash 命令注册表）/ `connection`（ws 连接管理）/ `room_list`（房间列表渲染）/ `turn_state`（turn 状态机）/ `envelope_router`（envelope 分派）/ `sidebar`（侧栏渲染）/ `modals`（模态框）。
+- **`debug_panel.js` 模块化重构**（1 次提交，PR #9）：拆出纯工具模块（`debug_panel_utils.js`）与渲染树模块（`debug_panel_tree.js`），整文件从单一巨函数收敛成分层数据流。
+- **P10 聊天界面增强**（1 次提交，落后端 + 前端两条线）：
+  - **后端**：新建 `chahua/message_artifacts.py`（`MessageArtifactRegistry` + `ArtifactRef`）——per-room 落 `rooms/<id>/message_artifacts.jsonl` 把「这个 artifact 是哪条消息产出的」抓出来。`transport_bridge` 在写盘工具命中时 `record_pending(rel → message_id)`；`ArtifactDetector.detect` 在 pick 周期末 `consume_pending` 取出 + 持久化 + emit envelope 多挂 `originated_message_id`；`emit_room_history` 按 message_id 投影 `originated_artifacts`，刷新 / 切房后挂件还原。`download_file` inbound 加可选 `purpose ∈ {download, preview}`，envelope `file_download` 原样回声、`_fail_download` 同步带 purpose。shell / MCP 类 args-unknown 工具走「TOOL_START 冻 baseline → TOOL_COMPLETE diff」回填 pending（滚动 baseline 单次 bind 内共享）。`schema_version` 不 bump、不改 transcript.jsonl 行结构。
+  - **前端**：新增 `renderMermaidIn`（mermaid 懒加载 + SVG 手工 sanitize，DOMPurify 对 `<foreignObject>` 会剥光 mermaid v11 节点 label）+ `attachArtifactToBubble` / `resolveArtifactPreview` / `clearPendingArtifactPreviews`。图片白名单 `{png, jpg, jpeg, gif, webp}` 走内嵌懒预览（`download_file purpose=preview` 拉字节）；SVG / 其它扩展走 pill 下载链（SVG 可内嵌 `<script>` 保守不渲）。envelope_router 拆出 `TASK_ARTIFACT_ADDED` 命中分支（挂件 vs 系统气泡兜底）+ `FILE_DOWNLOAD` 按 purpose 分流。
+  - **Codex review 修**：`message_artifacts._load_from_disk` 拒 `share/` 段 traversal（与 `_normalize_share_rel` 对称） / `transport_bridge._consume_tool_diff` 不在 bind 外回填 `_diff_baseline`（防晚到 TOOL_COMPLETE 污染下次 bind 的首扫盘）。
+- **P10.5 文档定稿**（1 次提交）：CLAUDE.md 「任务房间」/ 「权限、持久化、事件契约」加 P10 不变量，新增「聊天界面渲染（P10）」section；DESIGN.md §9.x 新增 P10 sub-section，5 条不变量明细同款体例。
+- **Yvonne 角色加 `create_image` skill**（1 次提交）：按用户提示词直接生成图像，封装四种生图后端（gpt / nanobanana / seedreamv5 / wan）由 `--model` 选择；支持画幅 / 质量 / 出图张数；不强制输出位置、agent 据上下文选目标目录。persona-bundled skill，零后端改动。
+
+## 模块新增（同期）
+
+- `chahua/room_runtime.py` —— `RoomRuntime` 数据契约 + `RoomEventRouter` 可变路由 sink + in-flight 槽与生命周期方法。
+- `chahua/message_artifacts.py` —— message ↔ artifact 关联注册表，落 `message_artifacts.jsonl`。
+- `app/renderer/message_filter.js` / `commands.js` / `connection.js` / `room_list.js` / `turn_state.js` / `envelope_router.js` / `sidebar.js` / `modals.js` —— renderer.js 拆出的 8 个子模块。
+- `app/renderer/debug_panel_utils.js` / `debug_panel_tree.js` —— debug_panel.js 拆出的 2 个子模块。
+- `examples/personas/Yvonne/skills/create_image/` —— Yvonne 角色的 persona-bundled 生图 skill。
+- `docs/P9-切房后房间后台续跑.md` —— P9 设计文档。
+- `docs/P10-聊天界面增强.md` —— P10 设计文档。
+
+## Release prep
+
+- 版本号 `0.1.2 → 0.1.3`：`pyproject.toml` / `chahua/__init__.py` / `app/package.json` / `app/package-lock.json` 四处同步。
+- CHANGELOG：`[Unreleased]` rename 为 `## [0.1.3] - 2026-05-23` + 加发布说明链接。
+- 测试套：999 passed in ~47s，零 fail 零 skip（v0.1.2 收线 860 → +139）。
+
+## 已知未做
+
+- **Windows .exe** 实跑：接缝（platform 分支 / sidecar resolver / stdin EOF graceful shutdown / `build.win` 配置 / `mklink /J` junction 兜底）从 v0.1.0 起一直就位，但还没在 Windows 主机 / CI matrix 端真正跑过 `npm run build:win`。
+- **macOS 签名 / 公证**：.dmg 仍未签名，用户双击仍会 Gatekeeper 红屏；ctrl-click → 打开 走一次即可。脱 Gatekeeper 警告需 Apple Developer ID（$99/年）。
+- **ACP 异构茶客**：仍只支持 agentao 驱动的茶客。接第一个非 agentao 的 ACP 茶客（`transport = "acp"`）是后续大版本。
+- **同名 artifact 覆写不重新挂件**：茶客在消息 A 写 `foo.png` → 消息 A 渲挂件；消息 B 再写同名 `foo.png` → `ArtifactDetector.detect` 用 `new_names = current - prev` diff，第二次 `foo.png` 已在 `prev` 中、不 emit envelope —— 消息 B 的气泡不会渲挂件。fix 需要 detect 额外感知 mtime / hash 才能识别「同名内容已变」。MVP 视为可接受。
+- **MTS 不跨断线 / 重启存活**：`ManagedSession` 是瞬态运行态，断线即结束（`user_cancel`），不做持久化恢复——刻意选择，与 `_handoff_queue` 同语义。**P9 起切房不再结束 MTS**：旧前台 busy 转后台续跑，MTS 在后台自驱直到自然收尾。
+- **后台房间无独立 UI 入口**：进行中徽标是房间列表上的被动标识；后台房不能像通知中心一样集中管理（每房进度条 / 一键全停等），刻意推后到有用户实际需求再做。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.3.dev0"
+version = "0.1.3"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "chahua"
-version = "0.1.3.dev0"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "agentao" },


### PR DESCRIPTION
## Summary
- 版本号 `0.1.2 → 0.1.3`：`pyproject.toml` / `chahua/__init__.py` / `app/package.json` / `app/package-lock.json`（两处）/ `uv.lock` 五处同步去 `dev` 后缀。
- CHANGELOG：`[Unreleased]` rename 为 `## [0.1.3] - 2026-05-23` + 加发布说明链接；列 P9 / P9.4 / P10 / renderer.js & debug_panel.js 重构 / Yvonne create_image skill 五大块。
- `docs/releases/v0.1.3.md`：新建，对齐 `v0.1.2.md` 体例（标题 / 亮点 / 里程碑按提交序 / 模块新增 / 已知未做）。

## Test plan
- [x] `uv run pytest` —— 999 passed in ~45s
- [x] `node --check` —— 6 个改动 / 关键 renderer 模块全过
- [ ] 合 main 后打 `v0.1.3` annotated tag
- [ ] `cd app && npm run build:mac` 出 `chahua-0.1.3-mac-arm64.dmg`
- [ ] `gh release create v0.1.3 <dmg> --notes-file docs/releases/v0.1.3.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)