### PR TITLE
chahua: 开 v0.1.4 开发周期 —— 版本号 0.1.3 → 0.1.4.dev0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.3",
+  "version": "0.1.4-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.3",
+      "version": "0.1.4-dev",
       "dependencies": {
         "dompurify": "^3.4.3",
         "marked": "^18.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.3",
+  "version": "0.1.4-dev",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.3"
+__version__ = "0.1.4.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.3"
+version = "0.1.4.dev0"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "chahua"
-version = "0.1.3"
+version = "0.1.4.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agentao" },


### PR DESCRIPTION
## Summary
- 版本号 `0.1.3 → 0.1.4.dev0`：`pyproject.toml` / `chahua/__init__.py` / `app/package.json` / `app/package-lock.json`（两处）/ `uv.lock` 五处同步加 `dev` 后缀。

## Test plan
- [x] `grep -n version` 五处一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)