### PR TITLE
v0.1.4 release prep —— 版本号去 dev + CHANGELOG + 发布说明

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-05-25
+
+详见 [`docs/releases/v0.1.4.md`](docs/releases/v0.1.4.md)。
+
+### Added
+- **P11 后台 Agent —— 同房间 Agent 并行执行**（2026-05-24 ~ 2026-05-25，详见 [`docs/P11-后台 Agent.md`](docs/P11-后台%20Agent.md)）：把房间从「一个 in-flight turn」升级为「一个前台 turn + 多个并发后台 run」。同房间最多 4 条并发 bg run。
+  - **P11.1 用户手动后台指派**（C1-C11，12 commits）：`AgentRun` frozen dataclass + `RoomRuntime.agent_runs` / `agent_run_tasks` / `active_guest_names` 三件套；`BatchMessageSink` 事件白名单（流式 / debug 一律丢 + `TASK_PROPOSAL` 缓冲到 wrapper finally 才 flush）；`_run_agent_background` wrapper 两层 try/finally + 6 步收尾；`agent_run_start` / `agent_run_cancel` inbound + `/bg <茶客> <指令>` 斜杠命令 + UI 弹窗；4 道校验（target 在场 / task_id 未关闭 / `guest_busy(target) == False` / `len(agent_runs) < MAX_AGENT_RUNS_PER_ROOM=4`）；`cancel_and_drain_all()` 5 步 race-free 清理（带 MTS 先 `end_managed_session(user_cancel)` 再 cancel drain）；4 个 `AGENT_RUN_*` envelope + `room_info.background_runs` 字段（不 bump `schema_version`）；scoring busy 三档过滤（`find_user_mention` / broadcast / `scorables` 均排除 busy 茶客，gather 后重读 busy）；前端 sidebar 茶客行 `.guest-bg-run` 圆点指示 + composer 上方 bg run 列表条（per-run 取消）。
+  - **P11.2 茶客侧 `spawn_agent_run(s)` 工具**（C11 / C12 + 2 fix，4 commits）：`SpawnAgentRunTool` + `SpawnAgentRunsTool`（`AsyncToolBase` 子类经 `run_coroutine_threadsafe` 桥回 host event loop 让 `create_task` 工作）；上限 `max_agent_runs_per_tool_call = 4`；同批次 target 不可重复；server 端 `_start_agent_run` 单点登记 helper + `_make_start_agent_run(runtime)` 工厂（切房经 `_attach_runtime_state` 重绑回调）；MTS × spawn 边界：`intercept_task_proposal` 在 envelope 类型层过滤、`<managed_session>` prompt 第 ④ 条加「并发用 spawn_agent_runs 不用 propose_panel」提示。
+  - **P11.2.X MTS × bg run 续命闭环**（PR #14，含 Codex 11 轮 review 收敛 13 项）：管理者 spawn 的 bg run 完成时自动 enqueue 一次管理者复查 + 扣 1 budget。`AgentRun` 加 `mts_managed` / `mts_manager_at_spawn` / `mts_session_id_at_spawn` 三个 spawn 时刻冻结字段；`ManagedSession.session_id` 单调递增 counter 区分跨 MTS 实例（CPython 内存地址会被 GC 复用，不能用 `id()`）。`advance_after_bg_completion` 4 道守卫（MTS 活 / manager 身份 / session_id / stop_reason 含 `BUDGET_EXHAUSTED` + queue-empty 窄化防多 bg race 清队列）。bg wrapper finally step ⑤ 6 个 helper 实现「advance 单跑 + dispatch/advance 拆分 + 双路 deferral（user turn / handoff drain）+ non-FINISHED 兜底（CANCELLED/ERROR mts_managed bg）+ self_destruct 补 + 先 `-1` counter 再 evaluate 防自屏蔽」race-free 闭环。drain 收尾两处 `MANAGER_FINISHED` 都加 `has_pending_mts_bg()` 守卫，bg pending 时安静退出 drain。`busy_alive()` 接 `pending_mts_continuations` counter 防 deferred callback 前 background runtime self_destruct 误销。`_start_agent_run` 拒 `target == manager_guest`。Maya `task-management` SKILL.md MTS 分支同步从「不要 spawn」改为「可以 spawn，每 bg 完成系统自动调度复查 1 次扣 1 budget」+ 新增「激活前提」段限制 SKILL 只在有 `<current_task>` 块时执行。
+
+### Changed
+- **orchestrator 按子域拆 5 个 slot**（2026-05-24，PR #13）：把 1500+ 行的 `Orchestrator` 主类按子域拆成 5 slot 模块（`_orchestrator_chain.py` AIChainOps / `_orchestrator_handoff_drain.py` HandoffDrainOps / `_orchestrator_handoff_queue.py` HandoffQueueOps / `_orchestrator_managed_session.py` ManagedSessionOps / `_orchestrator_scoring.py` ScoringOps），主类经 `_install_orchestrator_slots(orch)` 单点装配。公开 API 全部保兼容（薄转发 / `@property` + setter），既有 1000+ 测试零改动。
+
 ## [0.1.3] - 2026-05-23
 
 详见 [`docs/releases/v0.1.3.md`](docs/releases/v0.1.3.md)。

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.4-dev",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.4-dev",
+      "version": "0.1.4",
       "dependencies": {
         "dompurify": "^3.4.3",
         "marked": "^18.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.4-dev",
+  "version": "0.1.4",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.4.dev0"
+__version__ = "0.1.4"

--- a/docs/releases/v0.1.4.md
+++ b/docs/releases/v0.1.4.md
@@ -1,0 +1,65 @@
+# v0.1.4 —— 同房间后台 Agent 并行执行（2026-05-25）
+
+继 v0.1.3「切房后房间后台续跑 + 聊天界面增强」之后第五个版本。本版围绕一条主线：**P11 后台 Agent —— 同房间 Agent 并行执行**。把房间从「一个 in-flight turn」升级为「一个前台 turn + 多个并发后台 run」，让用户既能让茶客在背景里跑长任务（自己继续与别的茶客聊），也能让管理者茶客一回合并发派发多路独立工作。期间还做了 orchestrator 按子域拆 5 个 slot 的重构。1154 测试全过（v0.1.3 收线 999 → +155）。
+
+## 亮点
+
+- **同房间后台 Agent 并行执行**：以前房间只能跑一个 in-flight turn —— 一个茶客发完话才能轮到下一个。现在用户可以「右键茶客 → 后台运行」或 `/bg <茶客> <指令>` 派一条后台 run，茶客在后台独立执行（用自己的 LLM client / tools / cwd），用户继续与别的茶客对话，完成后追加一条普通茶客气泡到聊天区。同房间最多 4 条并发 bg run。
+- **茶客主动调度并发**：管理者茶客可调 `spawn_agent_run({target, instruction})` 立刻派 1 条后台 run，或 `spawn_agent_runs([{target, instruction}, ...])` 同批次并发派 ≤4 条 —— 与 `propose_panel`（用户采纳后串行 drain）的关键区别：spawn 是**真并发**（多位茶客同时在后台干活）。Maya 任务管理 skill 同步升级，支持「3 路并发审稿」典型场景。
+- **MTS × bg run 续命闭环**：MTS 管理者 spawn 的每个 bg run 完成后自动调度管理者复查一次 + 扣 1 budget —— 完整闭环「分派 → 等待 → 自动复查」，不再需要用户介入。修了用户报的「在托管会话中，当 Maya 开始调度多 Agent 并行执行后，托管会话直接结束了」bug。
+- **busy 三档过滤 + 视觉指示**：bg run 占用的茶客不接 `@` 提到 / 不参与打分 / 自然完成后回归；前端 sidebar 茶客行加进度指示（`.guest-bg-run` 圆点），composer 上方实时显示后台 run 列表条（可独立取消）。
+- **orchestrator slot 重构**：主类按子域拆 5 slot（AIChainOps / HandoffDrainOps / HandoffQueueOps / ManagedSessionOps / ScoringOps），主类回归核心调度状态机；公开 API 全部保兼容（薄转发 / @property + setter），既有 1000+ 测试零改动。
+
+## 里程碑（按提交序）
+
+- **orchestrator 按子域拆 5 个 slot**（提交 `ecfcee2`，PR #13）：把 1500+ 行的 `Orchestrator` 主类按子域拆成 5 个 slot 模块（`_orchestrator_chain.py` AIChainOps / `_orchestrator_handoff_drain.py` HandoffDrainOps / `_orchestrator_handoff_queue.py` HandoffQueueOps / `_orchestrator_managed_session.py` ManagedSessionOps / `_orchestrator_scoring.py` ScoringOps），主类经 `_install_orchestrator_slots(orch)` 单点装配。公开 import 路径不动；主类必须保留 `_run_ai_chain` / `_intercept_task_proposal` 同名 method（被 monkeypatch.setattr 替换 / `set_task_proposal_hook` 取 bound method）；`_managed_session` / `_handoff_queue` 走 `@property` + setter 让测试直赋兼容；既有 999 测试零改动。
+- **P11 设计稿落地**（提交 `5cc7520`）：新建 [`docs/P11-后台 Agent.md`](../P11-后台%20Agent.md)，定义 `AgentRun` / `RoomRuntime` 扩展 / `BatchMessageSink` / wrapper finally 6 步 / `agent_run_*` 4 个 envelope / Phases 分块（P11.1 用户手动 / P11.2 茶客 spawn）/ Non-Goals。
+- **P11.1 用户手动后台指派**（C1-C11，12 次提交）：
+  - **C1 `AgentRun` + `RoomRuntime` 扩展**：`chahua/agent_run.py` 新建 `AgentRun` frozen dataclass（`run_id` / `room_id` / `guest_name` / `instruction` / `task_id` / `issued_by` / `source_guest` / `created_at_ms`）；`RoomRuntime` 加 `agent_runs` / `agent_run_tasks` / `active_guest_names` 三件套 + `has_active_runs()` / `busy_alive()` / `guest_busy()` 方法。
+  - **C2 `Orchestrator.active_guest_names` 注入**：`server` 在 `_attach_runtime_state` 把 `runtime.active_guest_names` 同 set 实例绑到 `orchestrator.active_guest_names`；`ScoringOps.let_speak` 在 `await guest.speak(...)` 外包 `try: add → finally: discard`，让前台 / handoff 路径也参与 `guest_busy()` 视图（与 bg run 共享同一互斥域）。
+  - **C3 4 个 `AGENT_RUN_*` 事件 + `room_info.background_runs` 字段**：新增 `AGENT_RUN_STARTED` / `_FINISHED` / `_CANCELLED` / `_ERROR` envelope（不 bump `schema_version`，沿用「旧前端忽略未知 type」口径）；`room_info` 加 `background_runs` 字段每批权威覆盖。
+  - **C4 `TeaGuest.speak(record_debug=False)` 参数**：bg run wrapper 期间调 `speak(record_debug=False)`，wrapper 内 `self._recorder` 替成 `NOOP_RECORDER`，不写 `debug/turns.jsonl` / `debug/prompts/`（防 bg run 污染前台取证视图）。
+  - **C5 `BatchMessageSink` + `render_agent_run_block`**：新建 `chahua/agent_run_sink.py`（`BatchMessageSink` 包真 router、按白名单分流：`message_start` / `_delta` / `guest_thinking` / `tool_*` / `turn_*` 一律丢，`message_end(ok)` 补 `data.run_id` 放行，`TASK_PROPOSAL` 缓冲到 wrapper finally 才 `flush_to(router)`），`render_agent_run_block` 给 bg agent 上下文加 `<agent_run_task>` 块注入指令。
+  - **C6 `_run_agent_background` wrapper**：bg run 核心执行入口（两层 try/finally + 每步 best-effort）。内层 finally 5 步：detect_new_artifacts → flush_propose_buffer → pop registry → emit terminal → 外层 finally discard guest_name + `_maybe_self_destruct_background_runtime`。
+  - **C7 `busy_alive()` 窄替换 3 处**：`_switch_room` demote / `_maybe_self_destruct_background_runtime` / `_rooms_available_with_busy`。**前台 turn 控制（cancel 按钮 / 单 in-flight 防御）仍走 `inflight_alive()`**，后台 bg run 不能被「停止当前回答」误杀。
+  - **C8 `agent_run_start` / `agent_run_cancel` inbound**：用户经 UI 弹窗 / `/bg` 命令派 bg run 走 `agent_run_start`；4 道校验（target 在场 / task_id 未关闭 / `guest_busy(target) == False` / `len(agent_runs) < MAX_AGENT_RUNS_PER_ROOM=4`）；`agent_run_cancel {run_id}` 单条 cancel。
+  - **C9 清理 5 步 + ws 断开分流**：`RoomRuntime.cancel_and_drain_all()` 5 步 race-free（同步 cancel 前台 turn → 同步 cancel 全部 `agent_run_tasks` → `await gather` drain bg → `await` drain 前台 → `session.close()`），带 MTS 的 runtime 先 `end_managed_session(user_cancel)` 再 cancel drain；`_serve_one` finally 走 `_aclose_background_runtimes()` 清后台、留前台供重连复用。
+  - **C10 前端 `/bg` + sidebar 指示 + 列表条 + 事件分叉**：composer 上方 bg run 列表条（per-run 取消按钮）、sidebar 茶客行 `.guest-bg-run` 圆点指示、`/bg <茶客> <指令>` 斜杠命令、`envelope_router` 4 个 `AGENT_RUN_*` 事件分叉。
+  - **C11 scoring busy 三档过滤 + gather 后重读 busy**：`find_user_mention` 命中 busy 名整个 `@` token 忽略（`@busy @ok` 仍能路由到 ok）；broadcast winners 过滤掉 busy；scoring 路径 `scorables` / `cooled` 都排除 busy；scoring 并发 gather 之后重读 busy（避免「scoring 选中后真要 speak 时已被别处占了」）。
+  - **Codex review 修**（C9 / C11 各一轮）：清理路径 5 步分级排序 / pre-start cancel race 兜底 sweep / scoring 三档桶 reorder 等共 17 项整改。
+- **P11 文档对齐 + CLAUDE.md 压缩重写**（提交 `e0abb42`）：P11 实现完整覆盖 P11.1 全 11 个 chunk + 设计落地后，CLAUDE.md 加 「后台 Agent（P11，bg run / 并行执行）」section + 11 条不变量；DESIGN.md §11 新增「P11 后台 Agent」段。
+- **P11.2 C11 `spawn_agent_run(s)` 茶客侧工具**（提交 `cb36c3a` + 1 fix）：`chahua/agent_run_tools.py` 新建 `SpawnAgentRunTool` + `SpawnAgentRunsTool`（`AsyncToolBase` 子类，`async_execute` 走 `run_coroutine_threadsafe` 桥回 host event loop 让 `create_task` 工作）；上限 `max_agent_runs_per_tool_call = 4`；同批次 target 不可重复；server 端 `_start_agent_run` 单点登记 helper + `_make_start_agent_run(runtime)` 工厂（按 runtime 绑回调，切房经 `_attach_runtime_state` 重绑）。
+- **P11.2 C12 MTS × `spawn_agent_run` 边界 + 管理者 prompt 提示**（提交 `44953f0` + 1 fix）：`ManagedSessionOps.intercept_task_proposal` 在 envelope 类型层即过滤（只拦 TASK_PROPOSAL、不碰 AGENT_RUN_*）；`<managed_session>` prompt 块第 ④ 条加「需要并发用 spawn_agent_runs，不用 propose_panel」；MTS 启动提示同步。
+- **P11.2.X MTS × bg run 续命闭环**（提交 `ef421c6`，PR #14，含 Codex 11 轮 review 收敛 13 项 finding）：
+  - **设计**：管理者 spawn 的 bg run 在完成时自动 enqueue 一次管理者复查 + 扣 1 budget；与 worker→manager 桥语义对齐。
+  - **三个 spawn 时刻冻结字段**（`AgentRun.mts_managed` / `mts_manager_at_spawn` / `mts_session_id_at_spawn`）+ `ManagedSession.session_id` 单调递增 counter 区分跨 MTS 实例（CPython 内存地址会被 GC 复用，不能用 `id()`）。
+  - **`advance_after_bg_completion` 4 道守卫**：MTS 活 / manager 身份 / session_id / stop_reason（含 `BUDGET_EXHAUSTED` + queue-empty 窄化防多 bg race 清队列）。
+  - **wrapper finally step ⑤ 完整闭环**：6 个 helper 实现「advance 单跑 + dispatch/advance 拆分 + 双路 deferral（user turn / handoff drain）+ non-FINISHED 兜底 + self_destruct 补 + 先 `-1` counter 再 evaluate 防自屏蔽」；race-free 应对「multi bg / cancelled bg / 新 user_message 抢占 inflight / 同管理者重启新 MTS」等并发场景。
+  - **drain 收尾守卫**：两处 `MANAGER_FINISHED` 都加 `has_pending_mts_bg()` 守卫，bg pending 时安静退出 drain 让 bg 完成回调来 wake。
+  - **`busy_alive()` 接 `pending_mts_continuations` counter**：防 deferred callback 前 background runtime self_destruct 误销。
+  - **Codex 11 轮 review 收敛 13 项**：P2 stop_reason guard / P1 busy_alive counter / P2 advance queue-empty guard / P2-A 守卫窄化 / P2-B self_destruct 补 / P2 session identity counter / P3 swap file / P2 re-defer race / P2 advance 单跑拆分 / P2 non-FINISHED 兜底 / P2 user turn race / P2 self-mask counter → round 11 报「未发现新回归」收敛。
+  - **Maya `task-management` SKILL.md 同步**：Step 3 / Step 4 MTS 分支从「不要 spawn」改为「可以 spawn，每位 bg 完成系统自动调度复查 1 次扣 1 budget」+ 同回合 spawn + propose 双扣提示 + spawn target ≠ self 限制；新增「激活前提」段限制 SKILL 只在有 `<current_task>` 块时执行。
+  - **新研究文档**：[`docs/研究-Maya-skill-并发与自动推进闭环.md`](../研究-Maya-skill-并发与自动推进闭环.md) 完整设计决策 + 三档方案选型记录。
+
+## 模块新增（同期）
+
+- `chahua/_orchestrator_chain.py` / `_orchestrator_handoff_drain.py` / `_orchestrator_handoff_queue.py` / `_orchestrator_managed_session.py` / `_orchestrator_scoring.py` —— orchestrator 拆出的 5 个子域 slot。
+- `chahua/agent_run.py` —— `AgentRun` frozen dataclass（含 P11.2.X 的 `mts_managed` / `mts_manager_at_spawn` / `mts_session_id_at_spawn` 三个 spawn 时刻冻结字段）。
+- `chahua/agent_run_sink.py` —— `BatchMessageSink`（bg run 期间事件白名单过滤 + run_id 注入 + TASK_PROPOSAL 缓冲）。
+- `chahua/agent_run_tools.py` —— `SpawnAgentRunTool` + `SpawnAgentRunsTool`（茶客侧 spawn 工具，`AsyncToolBase` 子类经 `run_coroutine_threadsafe` 桥回 host loop）。
+- `chahua/server_inbound_agent_run.py` —— `agent_run_start` / `agent_run_cancel` inbound handler。
+- `chahua/context_renderer.py::render_agent_run_block` —— `<agent_run_task>` 块（注入 bg run instruction 给被指派茶客）。
+- `app/renderer/bg_run_bar.js` —— composer 上方 bg run 列表条 + per-run 取消按钮。
+- `tests/test_mts_bg_spawn_reentry.py` —— P11.2.X 26 个 case，覆盖每条 Codex 整改 + race 场景。
+
+## 文档新增 / 大改
+
+- [`docs/P11-后台 Agent.md`](../P11-后台%20Agent.md) —— 完整 P11 设计稿（运行态 / 入口 / envelope / 后台执行路径 / 取消与清理 / MTS × spawn / 前端 / Phases / Non-Goals），P11.2.X 后 § MTS × spawn 重写续命闭环。
+- [`docs/研究-Maya-skill-并发与自动推进闭环.md`](../研究-Maya-skill-并发与自动推进闭环.md) —— P11.2.X 决策研究稿（三档方案 / 最终选型 / 落地 SKILL 改动）。
+- `CLAUDE.md` § 「后台 Agent（P11，bg run / 并行执行）」加 11 条不变量；bg wrapper finally 从 5 步改为 6 步；orchestrator slot 拆分 invariant 同步。
+
+## 已知未做
+
+- **P11.3 fan-in barrier**（研究稿档 3，自动 fan-in）：明确不做，「人在闭环」对 LLM 调度失控有保护作用。P11.2.X 续命闭环已覆盖核心场景，剩余「等齐全部 bg 才整合」由 Maya SKILL Step 4「数到齐」分支软处理（未到齐 → emit 等待 + 重 propose_delegate 自己留兜底卡）。
+- **多房间跨 ws 并行**：仍受单 ws 连接限制；多用户多 ws 由 SaaS 形态展开（不在本地桌面壳范围）。
+- **packaged 安装包未 Apple Developer ID 签名**：.dmg 仍未签名（同 v0.1.3，无 Developer ID），首次启动需用户在「系统设置 → 隐私与安全性」放行。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.4.dev0"
+version = "0.1.4"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "chahua"
-version = "0.1.4.dev0"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "agentao" },


### PR DESCRIPTION
## Summary

v0.1.4 发布准备 —— 把 0.1.4 开发周期累积的工作（P11 整套 + orchestrator slot 拆分）打包发布。

## 改动

- **版本号四处同步**（去 `.dev0` / `-dev` 后缀）：`pyproject.toml` / `chahua/__init__.py` / `app/package.json` / `app/package-lock.json`（顶层 + `packages.\"\"`）；`uv.lock` 自动同步。
- **CHANGELOG.md**：把 `## [Unreleased]` rename 成 `## [0.1.4] - 2026-05-25` + 上方留空。`Added` 写 P11 三个子段（P11.1 用户手动后台指派 / P11.2 spawn 工具 / P11.2.X MTS × bg run 续命闭环），`Changed` 写 orchestrator slot 拆分。
- **新建 [`docs/releases/v0.1.4.md`](docs/releases/v0.1.4.md)**：体例对齐 `v0.1.3.md`（标题 / 亮点 / 里程碑按提交序 / 模块新增 / 已知未做）。

## v0.1.4 内容（自 0.1.4-dev 周期累积）

- `ecfcee2` orchestrator 按子域拆 5 个 slot（PR #13）
- `5cc7520` P11 设计稿
- **P11.1 C1-C11**（12 commits）—— 用户手动后台指派完整闭环
- **P11.2 C11 / C12** + 2 fix（4 commits）—— 茶客侧 `spawn_agent_run(s)` 工具 + MTS 边界
- `e0abb42` P11 文档对齐 + CLAUDE.md 压缩重写
- **P11.2.X**（PR #14，Codex 11 轮 review 收敛 13 项）—— MTS × bg run 续命闭环

1154 测试全过（v0.1.3 收线 999 → +155）。

## Test plan

- [x] `uv run pytest` —— 1154 passed
- [ ] 合并后跑 `cd app && FORCE=1 npm run build:python && npm run build:mac` → 出 `app/dist/chahua-0.1.4-mac-arm64.dmg`（~157M 未签名）
- [ ] `git tag -a v0.1.4` + push tag
- [ ] `gh release create v0.1.4 <dmg> --notes-file docs/releases/v0.1.4.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)