### PR TITLE
Release v0.1.5 —— persona 包化 + MTS 待机闭环

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-05-28
+
+详见 [`docs/releases/v0.1.5.md`](docs/releases/v0.1.5.md)。
+
+### Added
+- **P12 persona 包 manifest**（2026-05-25 ~ 2026-05-26，详见 [`docs/P12-persona 包 manifest.md`](docs/P12-persona%20包%20manifest.md)）：persona 从「目录里散件约定」升级为带 `persona.toml` manifest 的安装单元。本步只立载体 + 最小字段集（`schema_version` / `display_name` / `summary` / `[defaults.guest]`），解决两个真痛点：`<Name>.toml.permission` 写了不生效、花名册能力摘要要手动喂。严格白名单（未知键 → `PersonaManifestError`）、`schema_version` 当前唯一合法值 = 1、消费路径 fail-fast（`discover_personas` 是唯一 `WARN+None` 例外）、`[defaults.guest]` + 顶层 `summary` 仅「加入房间」时一次性 inflate 之后与 manifest 解绑。
+  - **P12.1 内置 5 个 persona 迁 dir-form + manifest**：宝总 / 爷叔 / 汪小姐 / 玲子 / 范总 从 flat-form `<Name>.md` 迁到 dir-form `<Name>/<Name>.md` + `persona.toml`，用第一手案例验证 schema；`config.py::_try_p12_1_dir_form_rewrite` 加 backward-compat shim 让 pre-P12.1 老 room.toml 的 flat-form 内置路径仍可加载（+ WARN 一次）。
+  - **examples/personas 迁 legacy `<Name>.toml` → `persona.toml`**；`persona_import._validate_manifest_pre_write` 写盘前对采集字节做 manifest dry-run（坏 manifest → 不创建 target_dir）+ `load_persona_manifest` 跨平台 case-strict 守卫（`Persona.toml` 等错名同样拒）。
+- **P12.5 MCP env 变量插值**（2026-05-27，详见 [`docs/P12.5-MCP env 变量插值.md`](docs/P12.5-MCP%20env%20变量插值.md)）：persona sidecar `mcp.json` 与房间级 `[[guest.extra_mcp_servers]]` 的 `env` / `headers` / `args` 支持 `$VAR` / `${VAR}` 插值 —— 真密钥留 `.env`、包里只声明变量名。把 LLM 侧「API key 永不进 toml / envelope」不变量延伸到 MCP 侧「永不进 persona 包 / mcp.json」。
+- **P12.6 Personas 更新**（2026-05-28，详见 [`docs/P12.6-Personas 更新.md`](docs/P12.6-Personas%20更新.md)）：给「导入 persona」补一条生命周期 —— 导入时记 `.chahua-source.json` provenance（本地路径 / GitHub commit sha + 安装时间），导入 modal 加「已安装」页，检查更新 → 单个更新 / 全部更新 + 删除。manifest 加纯展示 `version` 字段（**绝不参与 status 判定** —— 内容信号 commit SHA / content_hash 唯一定「变没变」，降级也照样提示）。更新 = 全量替换 + 原子 swap（中断可崩溃恢复）；本地已改默认拒、须 `force` 才覆盖。4 个新 inbound + 1 个 `PERSONAS_INSTALLED` envelope，**不 bump `schema_version`**。含 Codex 7 轮 review 收敛（fail-closed 本地改动检测 / sha 刷新失败保旧基线 / 操作键精确匹配防误删 / symlink 拒绝 / `<name>.md` 存在性校验 / 绝对路径 provenance / bulk-update 口径对齐）。
+- **拍一拍 —— 双击茶客头像 → `handoff_delegate`**（2026-05-24，提交 `f94e175`）：双击 sidebar 茶客头像直接发起 delegate handoff，省去手敲。
+
+### Changed
+- **三大模块按子域拆分 helper**（2026-05-25，提交 `4f4b6cf`）：行为保持的纯重构 —— 把 server agent_run / tasks_store artifacts / transport artifact attribution 各抽出独立 helper 模块（`_server_agent_run.py` / `_tasks_store_artifacts.py` / `_transport_artifact_attribution.py`），公开 import 路径与运行行为不动。
+
+### Fixed
+- **P8.4 MTS 待机闭环 —— `MANAGER_FINISHED` 退役**（2026-05-27，详见 [`docs/P8.4-MTS 待机闭环.md`](docs/P8.4-MTS%20待机闭环.md)）：修 P8.3 语义缺陷「管理者一回合没派活就被当成任务完成、强制终结 MTS」。把「没派活」从**终结信号**改成**待机信号** —— MTS 保持活 + 清队列 + 状态条改「待机中」，等用户下一句话经既有 `submit_user_message` 自然续上（dormant 复活走 pre-enqueue manager kickoff + drain + skip chain）。终结 reason 从 6 收敛到 5（删 `manager_finished`）；管理者「我已完事」走 `task_propose_status("done")` → 用户采纳 → `task_closed`。前端「托管中（待机）」状态条由三源派生、不发新 envelope；托管运行 popover 管理者从任务负责人范围选取；含 Codex 5 轮 P2 收敛（dormant 复活 / busy manager 拒收 / dormant MTS 阻 bg runtime 销毁 / owner=user 退化全员 / 自指派 early swallow）。
+- **P11 C12 handoff 全家拒 busy 茶客**（2026-05-26，提交 `f1a43d1`）：delegate / review / panel inbound 准入校验拒绝正被后台 run 占用的茶客，防 `let_speak` × bg agent run 并发同一茶客（P8.4.9 后窄化为只查 `guest_in_bg_run` —— 前台 / handoff 占用仍可被 cancel+drain 抢占）。
+
 ## [0.1.4] - 2026-05-25
 
 详见 [`docs/releases/v0.1.4.md`](docs/releases/v0.1.4.md)。

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.5-dev",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.5-dev",
+      "version": "0.1.5",
       "dependencies": {
         "dompurify": "^3.4.3",
         "marked": "^18.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.5-dev",
+  "version": "0.1.5",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.5.dev0"
+__version__ = "0.1.5"

--- a/docs/releases/v0.1.5.md
+++ b/docs/releases/v0.1.5.md
@@ -1,0 +1,59 @@
+# v0.1.5 —— persona 包化（manifest / 来源追踪 / 更新）+ MTS 待机闭环（2026-05-28）
+
+继 v0.1.4「同房间后台 Agent 并行执行」之后第六个版本。本版有两条主线：**persona 包化**（P12 立 `persona.toml` manifest 载体 → P12.5 MCP 密钥从 env 取 → P12.6 来源追踪 + 检查/更新/删除，让 persona 从「拷进来的死资产」变成「可追踪来源、可同步上游的受管包」），以及 **P8.4 MTS 待机闭环**（修 P8.3「管理者没派活就被当成任务完成」的语义缺陷）。期间还落了 P11 C12 handoff 拒 busy、拍一拍、三大模块按子域拆 helper。1371 测试全过（v0.1.4 收线 1154 → +217）。
+
+## 亮点
+
+- **persona 现在是带 manifest 的安装单元**：每个 dir-form persona 可带 `persona.toml`（`schema_version` / `display_name` / `summary` / `[defaults.guest]` / 纯展示 `version`），picker 直接读 `display_name` + `summary`，加入房间时把 `[defaults.guest].permission` / `isolation` 一次性 inflate 进 room.toml —— 解决了老 `<Name>.toml.permission` 写了不生效、花名册摘要要手动喂两个痛点。内置 5 位茶客全部迁到 dir-form + manifest。
+- **导入的 persona 可追踪来源、可一键更新**：导入时记 `.chahua-source.json`（本地路径 / GitHub commit sha + 安装时间），导入 modal 多一个「已安装」页列出受管 persona，支持「检查更新 → 单个 / 全部更新」与删除。更新走全量替换 + 原子 swap（中断可崩溃恢复），本地改过的默认拒覆盖、须显式确认。心智对齐 npm `package.json` 锁来源 + `npm outdated` / `npm update`。
+- **MCP 密钥不再硬写进 persona 包**：`mcp.json` 与房间级 `extra_mcp_servers` 的 `env` / `headers` / `args` 支持 `$VAR` / `${VAR}` 插值，真密钥留 `.env`、包里只声明变量名 —— 可安全分发带 MCP 的 persona 包。
+- **托管会话不再「管理者没派活就直接结束」**：P8.4 把「管理者一回合没 propose delegate/panel」从终结信号改成**待机信号** —— MTS 保持活、清空队列、状态条显示「托管中（待机）」，等用户下一句话经既有路径自然续上。终结只剩 5 个有界 reason（删 `manager_finished`）。
+- **handoff / bg run 互斥更严**：delegate / review / panel 准入拒绝正被后台 run 占用的茶客，防同一茶客被前台 `speak` 与后台 agent run 同时驱动。
+
+## 里程碑（按提交序）
+
+- **拍一拍 —— 双击茶客头像 → `handoff_delegate`**（提交 `f94e175`，2026-05-24）：双击 sidebar 茶客头像直接发起 delegate handoff，省手敲 `@` / 命令。
+- **三大模块按子域拆分 helper**（提交 `4f4b6cf`，2026-05-25）：行为保持的纯重构 —— server agent_run / tasks_store artifacts / transport artifact attribution 各抽出独立 helper 模块（`_server_agent_run.py` / `_tasks_store_artifacts.py` / `_transport_artifact_attribution.py`），公开 import 路径与运行行为不动。
+- **P12 persona 包 manifest**（提交 `de038c2` design + `033370b`..`1f73a9b` C1-C5，2026-05-25 ~ 2026-05-26，详见 [`docs/P12-persona 包 manifest.md`](../P12-persona%20包%20manifest.md)）：
+  - **C1 `persona_manifest.py` 模块**：`PersonaManifest` frozen dataclass + 三级严格白名单（顶层 / `[defaults.guest]` / 未知键 → `PersonaManifestError`）；`schema_version` 当前唯一合法值 = 1；两条入口共享私有 `_parse_dict`（文件 `load_persona_manifest` / in-memory `parse_persona_manifest_bytes`）。
+  - **C2 `discover_personas` 接 manifest + picker UI 渲 summary**：picker 三级 fallback（`persona.toml`.display_name → 老 `<stem>.toml`.`[guest].name` → 文件名 stem），summary 仅 manifest 提供；坏 manifest WARN + 走 legacy 回退（discover 是唯一允许 `WARN+None` 的消费方）。
+  - **C3 inflate 全链路**：`[defaults.guest]` + 顶层 `summary` 仅「加入房间」时一次性 inflate；frontend → inbound → admin 全链路用 `None` 表示「用户未显式选」，admin 层三级 coalesce（入参 > manifest > `DEFAULT_MODE`）一律 `is not None`，禁 `or DEFAULT_MODE`（防 `""` 这类坏值被静默吞）。
+  - **C4 写盘前 dry-run 校验**：`persona_import` 在 `_write_files` 之前对采集字节做 manifest dry-run，坏 manifest 不创建 target_dir（防下次重导撞「已存在」）；附 Yvonne 示例 persona。
+  - **C5 CLAUDE.md 同步 manifest 8 条不变量**。
+- **P12.1 内置 5 个 persona 迁 dir-form + manifest**（提交 `a168954`，2026-05-26）：宝总 / 爷叔 / 汪小姐 / 玲子 / 范总 从 flat-form `<Name>.md` 迁到 dir-form `<Name>/<Name>.md` + `persona.toml`，用第一手案例验证 schema；`config.py::_try_p12_1_dir_form_rewrite` 加 backward-compat shim 让 pre-P12.1 老 room.toml 的 flat-form 内置路径仍可加载（+ WARN 一次，建议但不强制改 toml）。
+- **examples/personas 迁 legacy `<Name>.toml` → `persona.toml`**（提交 `92e6db7`，2026-05-26）：示例包统一到 P12 manifest 形态。
+- **P12 fix —— 跨平台 case-strict 守卫**（提交 `bc97c72`，2026-05-26）：`load_persona_manifest` 对根级小写 `persona.toml` 做精确匹配，`Persona.toml` 等错名在大小写不敏感 FS 上同样拒（旁路守卫）。
+- **P11 C12 —— handoff 全家拒 busy 茶客**（提交 `f1a43d1`，2026-05-26）：delegate / review / panel inbound 准入校验拒绝正被后台 run 占用的茶客，防 `let_speak` × bg agent run 并发同一茶客。（P8.4.9 后窄化为只查 `guest_in_bg_run` —— 前台 / handoff 占用仍可被 cancel+drain 抢占，drain 自身守卫仍用 `active_guest_names` 全集兜底。）
+- **P8.4 MTS 待机闭环 —— `MANAGER_FINISHED` 退役**（提交 `b3879b8`..`ad662f2`，2026-05-27，详见 [`docs/P8.4-MTS 待机闭环.md`](../P8.4-MTS%20待机闭环.md)）：
+  - **P8.4.1 待机闭环主体**：drain 收尾队列空 + MTS 活 → 保持 dormant 不终结；dormant 复活走 pre-enqueue 管理者 kickoff DELEGATE + drain + skip chain；dormant 期间 task 状态变更经 `check_after_task_change` 主动收尾（+ code-review 收敛 4 项）。
+  - **P8.4.2 / P8.4.3**：删 P11.2.X bg `MANAGER_FINISHED` emit + dormant 续接；删 `MANAGED_SESSION_REASON_MANAGER_FINISHED` 常量 + 前后端文案，终结 reason 从 6 收敛到 5（`budget_exhausted` / `task_closed` / `cap_reached` / `user_stopped` / `user_cancel`）。
+  - **P8.4.4 / P8.4.5 / P8.4.6**：`<managed_session>` 块新增「待机收尾」语义（没下一步就讲完、不强行 propose 是合法收尾）+ Maya SKILL.md 同步；前端「托管中（待机）」状态条由三源派生（MTS 状态 + handoff 队列长度 + 前台 in-flight）不发新 envelope；托管运行 popover 管理者从任务负责人范围选取。
+  - **Codex 5 轮 P2 收敛（P8.4.7 ~ P8.4.11）**：dormant 复活 + bg-run busy manager 拒收 / dormant MTS 阻 bg runtime 销毁（`busy_alive` 计入 `has_managed_session()`）/ P11 C12 over-shoot 窄化（inbound 准入只查 bg run）/ owner=user 时退化全员 / 自指派 early swallow（manager 自派 delegate 在 busy 期间直接吞掉、不渲卡）。
+- **P12.5 MCP env 变量插值**（提交 `fb9969b`，2026-05-27，详见 [`docs/P12.5-MCP env 变量插值.md`](../P12.5-MCP%20env%20变量插值.md)）：persona sidecar `mcp.json` 与房间级 `[[guest.extra_mcp_servers]]` 的 `env` / `headers` / `args` 支持 `$VAR` / `${VAR}` 插值，真密钥留 `.env`、包里只声明变量名。把「API key 永不进 toml / envelope」不变量延伸到 MCP 侧「永不进 persona 包 / mcp.json」。
+- **P12.6 Personas 更新**（提交 `92fb971`，2026-05-28，详见 [`docs/P12.6-Personas 更新.md`](../P12.6-Personas%20更新.md)，含 Codex 7 轮 review 收敛）：
+  - **记录**：导入时写 `.chahua-source.json` provenance（消费侧安装元数据，住目录内、绝不进 `persona.toml`）—— folder 存绝对 `source_path`、github 存 owner/repo/ref/path + best-effort commit sha。读容错（坏 provenance → WARN+None，只去掉「更新」能力、保留「删除」）。
+  - **展示**：`list_installed_personas` 列 `user_data_root` 下全部 dir-form（含无 provenance），导入 modal 加「已安装」页（导入 / 已安装两 tab）；manifest 新增**纯展示** `version` 字段。
+  - **同步**：检查更新 → 单个 / 全部更新 + 删除。`version` **绝不参与 status 判定** —— 内容信号（github commit SHA / folder content_hash）唯一定「变没变」，降级也照样 `update_available`。更新 = 全量替换 + 原子 swap（tmp 写新内容 + provenance → rename swap → 成功删 bak / 失败 restore），中断可崩溃恢复（孤儿 `.bak` 在 session 重建 / discovery / 已安装页三处消费路径还原）；本地已改默认拒、须 `force` 覆盖。
+  - **协议**：4 个新 inbound（`list_installed_personas` / `check_persona_updates` / `update_persona` / `delete_persona`）+ 1 个 `PERSONAS_INSTALLED` envelope，网络型操作走 `asyncio.to_thread`，**不 bump `schema_version`**。
+  - **Codex 7 轮收敛**：fail-closed 本地改动检测 / sha 刷新失败保旧基线（不退化 None 永久禁更新）/ 操作键须与目录名精确匹配（防畸形名误删别的 persona）/ symlink persona 目录拒绝 / 更新前 `<name>.md` 存在性校验（防 md 删/改名后房间路径失效）/ 绝对路径 provenance（不依赖 cwd）/ 前端「全部更新」与逐行同口径。
+
+## 模块新增
+
+- `chahua/persona_manifest.py` —— P12 `persona.toml` 解析（`PersonaManifest` frozen dataclass + 三级严格白名单 + 文件 / in-memory 两入口）。
+- `chahua/_server_agent_run.py` / `chahua/_tasks_store_artifacts.py` / `chahua/_transport_artifact_attribution.py` —— 三大模块按子域拆出的行为保持 helper。
+- P12.6 的 provenance / 检查 / 更新 / 删除生命周期落在既有 `chahua/persona_import.py`（`PersonaSource` / `read_source` / `write_source` / `_content_hash` / `check_persona_update` / `update_persona` / `delete_persona` / `recover_interrupted_persona_updates`）；`chahua/admin_persona.py` 加 `list_installed_personas`；`chahua/server_inbound_io.py` 加 4 个 inbound handler；`chahua/events.py` 加 `PERSONAS_INSTALLED`。
+- 新增测试：`test_persona_manifest.py` / `test_persona_import_manifest.py` / `test_admin_persona_manifest_integration.py` / `test_admin_guest_inflate.py` / `test_admin_room_inflate.py` / `test_config_p12_1_backward_compat.py` / `test_inbound_admin_manifest_notice.py` / `test_inbound_admin_permission_none.py`（P12）；`test_mcp_env_expand.py`（P12.5）；`test_persona_provenance.py` / `test_persona_update.py` / `test_persona_version_display.py` / `test_persona_delete.py` / `test_admin_list_installed_personas.py` / `test_inbound_persona_update.py`（P12.6）；`test_mts_dormant.py`（P8.4）；`test_handoff_bg_busy.py`（P11 C12）。
+
+## 文档新增 / 大改
+
+- [`docs/P12-persona 包 manifest.md`](../P12-persona%20包%20manifest.md) —— manifest 载体设计 + 字段路线图（为什么 P12 字段这么少 / 后续 P12.2~P12.4 按真实痛点加）。
+- [`docs/P12.5-MCP env 变量插值.md`](../P12.5-MCP%20env%20变量插值.md) —— MCP 密钥插值设计。
+- [`docs/P12.6-Personas 更新.md`](../P12.6-Personas%20更新.md) —— provenance / 已安装页 / 检查-更新-删除三层设计 + 承重不变量。
+- [`docs/P8.4-MTS 待机闭环.md`](../P8.4-MTS%20待机闭环.md) —— `MANAGER_FINISHED` 退役 + 待机语义 + dormant 复活路径。
+- `CLAUDE.md` 加「persona 包 manifest（P12）」「Personas 更新（P12.6）」两段不变量，并在 MTS / handoff / 后台 Agent 段回填 P8.4.x / P11 C12 的语义修正。
+
+## 已知未做
+
+- **P12.2 ~ P12.4 manifest 后续字段**：`[requires].mcp_servers` / `skills`（装前校验）、`[[example_tasks]]`（装完一键起任务房）、`authors` / `homepage` / `license` + registry index（跨用户分发、`chahua persona search`）—— 按真实社区包跑出的痛点逐步加，不预留口袋。
+- **persona 更新不影响在跑的房间**：更新 / 删除只改磁盘，已构造的 `TeaGuest` 不受影响，下次 session 重建才生效 / 才因路径缺失报错（不主动扫房间 toml 拦截删除，交给既有 session 重建边界 + 前端 `confirm()` 文案）。
+- **packaged 安装包未 Apple Developer ID 签名**：.dmg 仍未签名（同 v0.1.3 / v0.1.4，无 Developer ID），首次启动需用户在「系统设置 → 隐私与安全性」放行。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.5.dev0"
+version = "0.1.5"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
v0.1.5 发布材料 + 版本号去 dev 后缀。功能代码（P12 / P12.5 / P12.6 / P8.4 / P11 C12 / 拍一拍 / 模块拆分）已在 `main`，本 PR 只做发版收尾：

- **CHANGELOG.md**：新增 `## [0.1.5] - 2026-05-28`（Added / Changed / Fixed，覆盖 v0.1.4 以来 25 个提交），上方保留空 `## [Unreleased]`。
- **docs/releases/v0.1.5.md**：按 v0.1.4 体例写发布说明（亮点 / 里程碑按提交序 / 模块新增 / 文档新增 / 已知未做）。
- **去 dev 后缀**：`0.1.5.dev0` / `0.1.5-dev` → `0.1.5`（`pyproject.toml` / `chahua/__init__.py` / `app/package.json` / `app/package-lock.json` 顶层 + `packages.""`）。

两条主线：**persona 包化**（P12 manifest → P12.5 MCP 密钥 env 化 → P12.6 来源追踪 / 检查·更新·删除）+ **P8.4 MTS 待机闭环**（`MANAGER_FINISHED` 退役）。

## Test plan
- [x] `uv run pytest` —— 1371 passed（合并前已绿）
- [x] `chahua.__version__ == 0.1.5`、5 处版本字符串无残留 dev
- [ ] **前端真机验证**：P12.6「已安装」页 / 检查·更新·删除 / 头像缩略图（合并后出包前在 Electron 走一遍）
- [ ] 合并 `main` 后打 annotated tag `v0.1.5`
- [ ] `npm run build:mac` 出 dmg → `gh release create v0.1.5 <dmg> --notes-file docs/releases/v0.1.5.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)