### PR TITLE
开 v0.1.6 开发周期 —— 版本号 0.1.5 → 0.1.6.dev0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.5",
+  "version": "0.1.6-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.5",
+      "version": "0.1.6-dev",
       "dependencies": {
         "dompurify": "^3.4.3",
         "marked": "^18.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.5",
+  "version": "0.1.6-dev",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.5"
+__version__ = "0.1.6.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.5"
+version = "0.1.6.dev0"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
v0.1.5 已发布（tag + GitHub Release 就位）。开 v0.1.6 开发周期，版本号挂 dev 后缀：

- `pyproject.toml` / `chahua/__init__.py` → `0.1.6.dev0`
- `app/package.json` / `app/package-lock.json`（顶层 + `packages.""`）→ `0.1.6-dev`

## Test plan
- [x] 5 处版本字符串无残留 `0.1.5`
- [x] `chahua.__version__ == 0.1.6.dev0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)