### PR TITLE
chahua: uv.lock 同步版本 0.1.6.dev0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "chahua"
-version = "0.1.5.dev0"
+version = "0.1.6.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agentao" },


### PR DESCRIPTION
补齐 v0.1.6 开发周期的 lockfile 同步：`pyproject.toml` 已是 `0.1.6.dev0`（commit `bcd1772`），本 PR 让 `uv.lock` 里 `chahua` 包版本与之一致（`0.1.5.dev0 → 0.1.6.dev0`）。

纯 lockfile 单行同步，无依赖变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)