### PR TITLE
chahua: 修两个 bug —— 详细设置失败必提醒用户 + gemini/google provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - **拆 `persona_import.py` —— 抽出 `persona_github` / `persona_provenance`**（2026-05-28，提交 `d59b53c`）：行为保持的纯重构，把 P12.6 落在 `persona_import.py` 的 GitHub 拉取与 provenance 读写各抽出独立 helper 模块，公开 import 路径与运行行为不动。
 - **精简 CLAUDE.md 不变量 + §9 明细移出到 `docs/INVARIANTS.md`**（2026-05-28，提交 `7d59556`）：CLAUDE.md 不变量段只留「规则 + 关键 why」，完整 rationale / P-版本溯源 / 回归测试搬进 `docs/INVARIANTS.md`，两处约定「改不变量两处同步」。
 
+### Fixed
+- **茶客 / 房间详细设置失败时静默回滚 → 改为 NOTICE error 提醒用户**（2026-05-31）：admin 更新 handler（`update_guest_llm` / `update_room_llm` / `update_guest_permission` / `update_guest_isolation` / `update_guest_extra_mcp` / `add_guest` / `remove_guest` / `create_room` / `delete_room` / `set_persona_mcp_trust`）原先 catch-all 只 `_log.exception` + 重发 snapshot，用户看到设置悄悄回滚、毫无反馈。两条失败路径都补 NOTICE：① toml 校验失败（`admin.update_*` 抛 `ValueError`）；② 会话重建失败 —— `build_room_session` → `build_client` 缺 API key / 未知 provider 无 base_url 时抛 **`SystemExit`**（不是 `Exception` 子类！原 `except Exception` 根本没兜住，异常逸出），`_replace_session` 改 `except (Exception, SystemExit)` 单点兜底 + emit NOTICE。这正是「改了模型但没生效」最常见的真实场景。
+- **`gemini` 加入已知 provider 列表（也可写 `google`）**（2026-05-31）：`_DEFAULT_BASE_URLS` 加 `gemini` → Gemini Developer API 的 OpenAI 兼容端点（`generativelanguage.googleapis.com/v1beta/openai/`），可省 `base_url`；新增 `_PROVIDER_ALIASES`（`google` → `gemini`）+ `canonical_provider()`，toml / env 两条入口都归一到单一 canonical `gemini`，避免 `google/x` 与 `gemini/x` 各走一套 API key 环境变量名互相错配（默认 `GEMINI_API_KEY`，要 `GOOGLE_API_KEY` / Vertex 端点在 toml 显式写 `api_key_env` / `base_url` 覆盖）。
+
 ## [0.1.5] - 2026-05-28
 
 详见 [`docs/releases/v0.1.5.md`](docs/releases/v0.1.5.md)。

--- a/chahua/llm_spec.py
+++ b/chahua/llm_spec.py
@@ -32,6 +32,17 @@ _DEFAULT_BASE_URLS: dict[str, str] = {
     # 阿里云 DashScope 的 OpenAI 兼容端点。国际版走 dashscope-intl.aliyuncs.com，
     # 国内用户绝大多数走主域，差异让用户在 toml 里显式写 base_url 覆盖即可。
     "qwen": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    # Google Gemini 的 OpenAI 兼容端点（Gemini Developer API）。默认 api_key_env
+    # 走 GEMINI_API_KEY（见 provider_env_prefix）；要用 GOOGLE_API_KEY / Vertex 端点
+    # 在 toml 里显式写 api_key_env / base_url 覆盖即可。
+    "gemini": "https://generativelanguage.googleapis.com/v1beta/openai/",
+}
+
+# provider 别名 → canonical。``google`` 是 ``gemini`` 的常见同义写法，统一归一到
+# ``gemini`` —— 一个 canonical provider（env 前缀 / 默认 base_url / 展示字面量都一致），
+# 避免 ``google/x`` 与 ``gemini/x`` 各走一套 API key 环境变量名而互相错配。
+_PROVIDER_ALIASES: dict[str, str] = {
+    "google": "gemini",
 }
 
 # 闲聊场景调高，比 agentao 自带的 0.2 暖；可被 LLM_TEMPERATURE 覆盖。
@@ -54,8 +65,8 @@ def split_model_id(value: str) -> tuple[str, str]:
     取**第一个** ``/`` 作 provider/model 分隔 —— OpenRouter / LiteLLM 的 model id 普遍
     含 ``/`` 二级路径，必须保留。无 ``/`` 或两侧为空 → :class:`ValueError`。
 
-    返回的 provider 已 lowercase（与 :data:`_DEFAULT_BASE_URLS` 键风格一致）；model 保留
-    原大小写。
+    返回的 provider 已 lowercase + 别名归一（:data:`_PROVIDER_ALIASES`，如 ``google``
+    → ``gemini``，与 :data:`_DEFAULT_BASE_URLS` 键风格一致）；model 保留原大小写。
     """
     if "/" not in value:
         raise ValueError(
@@ -66,7 +77,18 @@ def split_model_id(value: str) -> tuple[str, str]:
         raise ValueError(
             f"model={value!r} 形态不合法 —— '/' 两侧都不能为空"
         )
-    return provider.strip().lower(), model.strip()
+    return canonical_provider(provider), model.strip()
+
+
+def canonical_provider(name: str) -> str:
+    """provider 名归一：lowercase + strip + 别名映射（``google`` → ``gemini``）。
+
+    toml / env 两条入口都过这里，保证同一 provider 不因写法不同走两套 env 前缀 /
+    默认 base_url。未知 provider 原样返回（lowercase），由下游 ``build_client`` 决定
+    是否需要显式 base_url。
+    """
+    norm = name.strip().lower()
+    return _PROVIDER_ALIASES.get(norm, norm)
 
 
 # toml 表层 LLM 字段的写出 / 解析顺序（model 在前 + 可选三项在后，与设计 §3 示例对齐
@@ -157,7 +179,7 @@ class LLMSpec:
         本方法返回的 spec ``api_key_env=None`` —— ``room_info`` 渲染时能看出"这是 env
         推断的默认 spec"（与 ``[room.llm]`` toml 显式配置形成对照）。
         """
-        provider = (os.environ.get("LLM_PROVIDER") or "openai").strip().lower() or "openai"
+        provider = canonical_provider(os.environ.get("LLM_PROVIDER") or "openai") or "openai"
         prefix = provider_env_prefix(provider)
 
         model = os.environ.get(f"{prefix}_MODEL")
@@ -184,7 +206,7 @@ class LLMSpec:
         spec = cls.try_from_env()
         if spec is not None:
             return spec
-        provider = (os.environ.get("LLM_PROVIDER") or "openai").strip().lower() or "openai"
+        provider = canonical_provider(os.environ.get("LLM_PROVIDER") or "openai") or "openai"
         prefix = provider_env_prefix(provider)
         known = ", ".join(sorted(_DEFAULT_BASE_URLS.keys()))
         raise SystemExit(

--- a/chahua/server.py
+++ b/chahua/server.py
@@ -757,8 +757,15 @@ class ChahuaServer:
         """
         try:
             new_session = build_room_session(new_room_dir, paths=self._paths)
-        except Exception:
+        except (Exception, SystemExit) as e:
+            # SystemExit（不是 Exception 子类！）—— build_client 在缺 API key /
+            # 未知 provider 无 base_url 时抛它，这正是"改了模型但没生效"最常见的原因。
+            # 不 emit NOTICE 用户只看到设置悄悄回滚、毫无反馈（本次 bugfix 的核心）。
             _log.exception("%s: build_room_session 失败", label)
+            self._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR,
+                text=f"设置未生效，已回滚到上一个可用配置：{e}",
+            )
             self._emit_room_info(sink)
             return False
         old = self._session

--- a/chahua/server_inbound_admin.py
+++ b/chahua/server_inbound_admin.py
@@ -79,10 +79,13 @@ class AdminHandlers:
             self.server._emit_notice(sink, level=NOTICE_LEVEL_ERROR, text=str(e))
             self.server._emit_room_snapshot(sink)
             return
-        except Exception:
+        except Exception as e:
             _log.exception("add_guest: persona=%r name=%r 失败", persona, name)
             # 写 toml 失败 / 校验失败：room.toml 已被回滚到 snapshot，session 还是旧的。
-            # 重发 snapshot 让前端 UI 复位（添加按钮的 loading 等状态消除）。
+            # NOTICE 说明原因 + 重发 snapshot 让前端 UI 复位（添加按钮的 loading 等状态消除）。
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"添加茶客失败：{e}"
+            )
             self.server._emit_room_snapshot(sink)
             return
         if not self.server._replace_session(room_dir, sink, label="add_guest"):
@@ -115,10 +118,13 @@ class AdminHandlers:
             return
         try:
             trust.set_mcp_trust(self.server._paths, persona_rel, trusted)
-        except Exception:
+        except Exception as e:
             _log.exception(
                 "set_persona_mcp_trust: persona_rel=%r trusted=%r 写盘失败",
                 persona_rel, trusted,
+            )
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"更新 MCP 信任失败：{e}"
             )
             self.server._emit_room_snapshot(sink)
             return
@@ -145,9 +151,12 @@ class AdminHandlers:
             admin.update_guest_permission(
                 paths=self.server._paths, room_dir=room_dir, name=name, permission=permission
             )
-        except Exception:
+        except Exception as e:
             _log.exception(
                 "update_guest_permission: name=%r permission=%r 失败", name, permission
+            )
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"权限设置未生效：{e}"
             )
             self.server._emit_room_snapshot(sink)
             return
@@ -171,9 +180,12 @@ class AdminHandlers:
             new_rc = admin.update_room_orchestrator(
                 paths=self.server._paths, room_dir=room_dir, overrides=overrides
             )
-        except Exception:
+        except Exception as e:
             _log.exception(
                 "update_room_orchestrator: overrides=%r 失败", overrides
+            )
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"编排参数未生效：{e}"
             )
             self.server._emit_room_snapshot(sink)
             return
@@ -196,9 +208,12 @@ class AdminHandlers:
                 paths=self.server._paths, room_dir=room_dir,
                 section=section, spec_dict=spec_dict,
             )
-        except Exception:
+        except Exception as e:
             _log.exception(
                 "update_room_llm: section=%r spec=%r 失败", section, spec_dict
+            )
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"模型设置未生效：{e}"
             )
             self.server._emit_room_snapshot(sink)
             return
@@ -222,9 +237,12 @@ class AdminHandlers:
                 paths=self.server._paths, room_dir=room_dir,
                 name=name, isolation=isolation,
             )
-        except Exception:
+        except Exception as e:
             _log.exception(
                 "update_guest_isolation: name=%r isolation=%r 失败", name, isolation
+            )
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"隔离设置未生效：{e}"
             )
             self.server._emit_room_snapshot(sink)
             return
@@ -246,9 +264,12 @@ class AdminHandlers:
                 paths=self.server._paths, room_dir=room_dir,
                 name=name, spec_dict=spec_dict,
             )
-        except Exception:
+        except Exception as e:
             _log.exception(
                 "update_guest_llm: name=%r spec=%r 失败", name, spec_dict
+            )
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"模型设置未生效：{e}"
             )
             self.server._emit_room_snapshot(sink)
             return
@@ -272,9 +293,12 @@ class AdminHandlers:
                 paths=self.server._paths, room_dir=room_dir,
                 name=name, servers=servers,
             )
-        except Exception:
+        except Exception as e:
             _log.exception(
                 "update_guest_extra_mcp: name=%r servers=%r 失败", name, servers
+            )
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"MCP 设置未生效：{e}"
             )
             self.server._emit_room_snapshot(sink)
             return
@@ -290,8 +314,11 @@ class AdminHandlers:
         room_dir = self.server._session.room_config.room_dir
         try:
             admin.remove_guest(paths=self.server._paths, room_dir=room_dir, name=name)
-        except Exception:
+        except Exception as e:
             _log.exception("remove_guest: name=%r 失败", name)
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"移除茶客失败：{e}"
+            )
             self.server._emit_room_snapshot(sink)
             return
         if not self.server._replace_session(room_dir, sink, label="remove_guest"):
@@ -326,10 +353,13 @@ class AdminHandlers:
             self.server._emit_notice(sink, level=NOTICE_LEVEL_ERROR, text=str(e))
             self.server._emit_room_snapshot(sink)
             return
-        except Exception:
+        except Exception as e:
             _log.exception("create_room: room_id=%r 失败", room_id)
-            # 创建失败：磁盘已 rmtree 回滚（admin.create_room 内部）；前端没切走，重发当
-            # 前 snapshot 让"创建中…"按钮态归位。
+            # 创建失败：磁盘已 rmtree 回滚（admin.create_room 内部）；前端没切走，NOTICE
+            # 说明原因 + 重发当前 snapshot 让"创建中…"按钮态归位。
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"创建房间失败：{e}"
+            )
             self.server._emit_room_snapshot(sink)
             return
         if not self.server._replace_session(rc.room_dir, sink, label=f"create_room→{rc.room_dir.name!r}"):
@@ -358,8 +388,11 @@ class AdminHandlers:
             admin.delete_room(
                 paths=self.server._paths, room_id=room_id, current_room_id=current
             )
-        except Exception:
+        except Exception as e:
             _log.exception("delete_room: room_id=%r 失败", room_id)
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"删除房间失败：{e}"
+            )
             self.server._emit_room_snapshot(sink)
             return
         _log.info("delete_room: %r 已删", room_id)

--- a/docs/releases/v0.1.6.md
+++ b/docs/releases/v0.1.6.md
@@ -20,6 +20,9 @@
   - **C3 打磨**：超视觉上限（20MB）的图 pill 提示「茶客看文本引用」；`TurnRecorder.record_message_start(images_rel=)` 记 rel-only（不记 bytes）；CLAUDE.md 模块行 / 不变量段 + `docs/INVARIANTS.md` §P13 同步。
   - **review 收敛**：C1/C2/C3 每步 code-review + codex review 全部 clean —— 修了「图泄漏到 AI 接力轮」（scope 到第一周期）、`share/.png` dotfile 漏白名单（`rpartition` stem 校验）、0 字节图让 agentao 预校验抛 ValueError（`size==0` 跳过）、paste/drop 绕过禁用按钮静默丢文件（补 setStatus 反馈）、`dragleave` 缺 `types.includes("Files")` 守卫（对齐 `dragenter`）。
   - **依赖**：agentao `0.4.6 → 0.4.8`（P13 前置，提供 `media_limits` / `arun(images=)` / reactive 退化）。
+- **bugfix：详细设置失败静默回滚 + gemini provider**（2026-05-31）：
+  - **设置失败必提醒用户**：茶客 / 房间详细设置（模型 / 权限 / 隔离 / MCP / 加删茶客 / 建删房间 / MCP 信任）失败时，admin handler 原先 catch-all 只 log + 重发 snapshot，用户看到设置悄悄回滚、毫无反馈 —— 现在每条失败路径都 emit NOTICE error。关键修复：会话重建时 `build_client` 缺 API key / 未知 provider 无 base_url 抛的是 **`SystemExit`**（不是 `Exception` 子类），原 `_replace_session` 的 `except Exception` 根本没兜住、异常逸出；改 `except (Exception, SystemExit)` 单点兜底 + NOTICE。这正是「改了模型但没生效」最常见的真实场景。
+  - **`gemini` / `google` provider**：`gemini` 进已知 provider 列表（自带 Gemini OpenAI 兼容端点默认 base_url，可省 `base_url`）；`google` 作为别名经 `canonical_provider()` 归一到 `gemini`，toml / env 两入口统一，避免两套写法各走一套 API key 环境变量名互相错配。
 
 ## 模块新增
 

--- a/tests/test_admin_settings_notice.py
+++ b/tests/test_admin_settings_notice.py
@@ -1,0 +1,83 @@
+"""茶客 / 房间详细设置失败时必发 NOTICE error 提醒用户（bugfix）。
+
+历史问题：admin 更新 handler 的 catch-all 只 `_log.exception` + 重发 snapshot，
+用户看到设置悄悄回滚、毫无反馈。两条失败路径：
+  ① toml 校验失败（``admin.update_*`` 抛 ValueError）—— handler catch-all。
+  ② 会话重建失败（``build_room_session`` → ``build_client`` 缺 API key 抛
+     **SystemExit**，不是 Exception 子类）—— ``_replace_session`` 兜底。
+两条都必须 emit NOTICE error。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chahua.events import ChahuaEventType, NOTICE_LEVEL_ERROR
+
+
+def _notices(events):
+    return [
+        e for e in events
+        if e.type == ChahuaEventType.NOTICE
+        and e.data.get("level") == NOTICE_LEVEL_ERROR
+    ]
+
+
+async def test_update_guest_llm_bad_spec_emits_notice(task_inbound_srv):
+    """toml 校验失败（未知 provider 且没给 base_url）→ NOTICE error 提醒用户。"""
+    session, srv = task_inbound_srv
+    events: list = []
+    sink = events.append
+
+    # 未知 provider + 无 base_url → admin.update_guest_llm 抛 ValueError。
+    srv.admin._update_guest_llm(
+        name="宝总",
+        spec_dict={"model": "nosuchvendor/some-model"},
+        sink=sink,
+    )
+
+    errs = _notices(events)
+    assert errs, "设置失败必须 emit 一条 NOTICE error"
+    assert "模型设置未生效" in errs[0].data["text"]
+
+
+async def test_replace_session_systemexit_emits_notice(task_inbound_srv, monkeypatch):
+    """模型本身合法（toml 校验过）但会话重建抛 **SystemExit**（build_client 缺 API
+    key 的真实形态）→ `_replace_session` 必须兜住 SystemExit（它不是 Exception 子类！）
+    + emit NOTICE，而不是让异常逸出 / 设置悄悄回滚。"""
+    import chahua.server as server_mod
+
+    session, srv = task_inbound_srv
+    events: list = []
+    sink = events.append
+
+    def _boom(*a, **k):
+        raise SystemExit("LLM provider='gemini'：缺少环境变量 GEMINI_API_KEY。")
+
+    monkeypatch.setattr(server_mod, "build_room_session", _boom)
+
+    # toml 写入成功（gemini 合法），随后 _replace_session → build_room_session → SystemExit。
+    srv.admin._update_guest_llm(
+        name="宝总",
+        spec_dict={"model": "gemini/gemini-2.5-pro"},
+        sink=sink,
+    )
+
+    errs = _notices(events)
+    assert errs, "会话重建失败（SystemExit）必须被兜住 + emit NOTICE，而不是悄悄回滚"
+    assert "设置未生效" in errs[0].data["text"]
+
+
+async def test_update_guest_llm_ok_no_error_notice(task_inbound_srv):
+    """正常更新（openai，env 已配 key）不该误报 NOTICE error。"""
+    session, srv = task_inbound_srv
+    events: list = []
+    sink = events.append
+
+    srv.admin._update_guest_llm(
+        name="宝总",
+        spec_dict={"model": "openai/gpt-5.4-mini"},
+        sink=sink,
+    )
+
+    assert not _notices(events), "成功更新不该 emit error NOTICE"

--- a/tests/test_llm_spec.py
+++ b/tests/test_llm_spec.py
@@ -10,7 +10,13 @@ import os
 
 import pytest
 
-from chahua.llm_spec import LLMSpec, split_model_id
+from chahua.llm_spec import (
+    LLMSpec,
+    _DEFAULT_BASE_URLS,
+    build_client,
+    canonical_provider,
+    split_model_id,
+)
 
 
 # ── split_model_id ────────────────────────────────────────────────────────
@@ -39,6 +45,57 @@ def test_split_model_id_valid(value, expected):
 def test_split_model_id_invalid(bad):
     with pytest.raises(ValueError):
         split_model_id(bad)
+
+
+# ── gemini / google provider（已知列表 + 别名归一）─────────────────────────
+
+
+def test_gemini_in_known_providers():
+    """``gemini`` 进已知 provider 列表，自带默认 base_url（可省 base_url）。"""
+    assert "gemini" in _DEFAULT_BASE_URLS
+    assert _DEFAULT_BASE_URLS["gemini"].startswith("https://generativelanguage.googleapis.com")
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("gemini/gemini-2.5-pro", ("gemini", "gemini-2.5-pro")),
+    # google 是 gemini 的别名，归一到 canonical gemini。
+    ("google/gemini-2.5-pro", ("gemini", "gemini-2.5-pro")),
+    ("GOOGLE/gemini-2.5-flash", ("gemini", "gemini-2.5-flash")),
+    (" google / gemini-2.5-pro ", ("gemini", "gemini-2.5-pro")),
+])
+def test_split_model_id_google_alias(value, expected):
+    assert split_model_id(value) == expected
+
+
+def test_canonical_provider_alias():
+    assert canonical_provider("google") == "gemini"
+    assert canonical_provider("GOOGLE") == "gemini"
+    assert canonical_provider("openai") == "openai"      # 非别名原样
+    assert canonical_provider(" Anthropic ") == "anthropic"
+
+
+def test_from_toml_google_normalizes_to_gemini():
+    """``google/...`` toml 写法归一到 gemini —— 单一 canonical provider，
+    env 前缀 / 默认 base_url / 展示字面量都走 gemini。"""
+    spec = LLMSpec.from_toml({"model": "google/gemini-2.5-pro"}, label="[[guest]] x")
+    assert spec.provider == "gemini"
+    assert spec.model == "gemini-2.5-pro"
+    assert spec.model_id == "gemini/gemini-2.5-pro"
+    assert spec.default_api_key_env() == "GEMINI_API_KEY"
+
+
+def test_from_toml_gemini_no_base_url_needed():
+    """gemini 在已知列表，不写 base_url 也能过 from_toml（不抛未知 provider）。"""
+    spec = LLMSpec.from_toml({"model": "gemini/gemini-2.5-flash"}, label="[[guest]] x")
+    assert spec.base_url is None
+
+
+def test_build_client_gemini(monkeypatch):
+    """gemini spec 缺 base_url 时用默认端点 + GEMINI_API_KEY 建 client 成功。"""
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-gemini-test")
+    spec = LLMSpec.from_toml({"model": "google/gemini-2.5-pro"}, label="[[guest]] x")
+    client = build_client(spec)  # 不抛 SystemExit
+    assert client is not None
 
 
 # ── LLMSpec.from_toml ─────────────────────────────────────────────────────


### PR DESCRIPTION
## 摘要

发布 v0.1.6 前补两个 bug。

## BUG 1 —— 茶客 / 房间详细设置失败时静默回滚，用户无反馈

设置失败有两条路径，原先都不提醒用户：

- **toml 校验失败**：10 个 admin 更新 handler（`update_guest_llm` / `update_room_llm` / `update_guest_permission` / `update_guest_isolation` / `update_guest_extra_mcp` / `add_guest` / `remove_guest` / `create_room` / `delete_room` / `set_persona_mcp_trust`）catch-all 只 `_log.exception` + 重发 snapshot，用户看到设置悄悄回滚、毫无反馈 → 每条补 `_emit_notice(error)`。
- **会话重建失败（核心）**：`build_room_session` → `build_client` 在缺 API key / 未知 provider 无 base_url 时抛 **`SystemExit`**，它**不是 `Exception` 子类** —— `_replace_session` 原 `except Exception` 根本没兜住、异常逸出。改 `except (Exception, SystemExit)` 单点兜底 + emit NOTICE。这正是「改了模型但没生效」最常见的真实场景。

两条路径互斥（校验先跑、失败即 return），不会双 NOTICE。

## BUG 2 —— `gemini` 加入已知 provider 列表（也可写 `google`）

- `_DEFAULT_BASE_URLS` 加 `gemini` → Gemini Developer API 的 OpenAI 兼容端点（`generativelanguage.googleapis.com/v1beta/openai/`），可省 `base_url`。
- 新增 `_PROVIDER_ALIASES`（`google` → `gemini`）+ `canonical_provider()`，toml / env 两条入口都归一到单一 canonical `gemini`，避免 `google/x` 与 `gemini/x` 各走一套 API key 环境变量名互相错配。默认 `GEMINI_API_KEY`；要 `GOOGLE_API_KEY` / Vertex 端点在 toml 显式写 `api_key_env` / `base_url` 覆盖。

## 测试

- 新增 12 个回归测试：`tests/test_admin_settings_notice.py`（3：toml 校验失败 NOTICE / `_replace_session` 兜 SystemExit + NOTICE / 正常更新不误报）+ `tests/test_llm_spec.py`（9：gemini 已知 / google 别名归一 / from_toml / build_client）。
- 全量 **1443 passed**。

CHANGELOG + `docs/releases/v0.1.6.md` 补 Fixed 段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)