### PR TITLE
chahua: 开 v0.1.7 开发周期 —— 版本号 0.1.6 → 0.1.7.dev0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.6",
+  "version": "0.1.7-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.6",
+      "version": "0.1.7-dev",
       "dependencies": {
         "dompurify": "^3.4.3",
         "marked": "^18.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.6",
+  "version": "0.1.7-dev",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.6"
+__version__ = "0.1.7.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.6"
+version = "0.1.7.dev0"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "chahua"
-version = "0.1.6"
+version = "0.1.7.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agentao" },


### PR DESCRIPTION
## 摘要

v0.1.6 已发布（Release + tag 完成），开 v0.1.7 开发周期：版本号挂 dev 后缀。

## 改动

版本号六处同步 `0.1.6` → `0.1.7.dev0`（python）/ `0.1.7-dev`（npm）：
- `pyproject.toml`
- `chahua/__init__.py`
- `app/package.json`
- `app/package-lock.json`（顶层 + `packages.""`）
- `uv.lock`（`uv sync` 同步）

CHANGELOG 顶部已有空 `## [Unreleased]` 段，本次不动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)