### PR TITLE
chahua: 开 v0.1.8 开发周期 —— 版本号 0.1.7 → 0.1.8.dev0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.7",
+  "version": "0.1.8-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.7",
+      "version": "0.1.8-dev",
       "dependencies": {
         "@highlightjs/cdn-assets": "^11.11.1",
         "dompurify": "^3.4.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.7",
+  "version": "0.1.8-dev",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.7"
+__version__ = "0.1.8.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.7"
+version = "0.1.8.dev0"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "chahua"
-version = "0.1.7"
+version = "0.1.8.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agentao" },


### PR DESCRIPTION
开启 v0.1.8 开发周期。版本号挂 dev 后缀，五处同步：

- `pyproject.toml` / `chahua/__init__.py` → `0.1.8.dev0`
- `app/package.json` / `app/package-lock.json`（顶层 + `packages.""`）→ `0.1.8-dev`
- `uv.lock` `name = "chahua"` 自包版本 → `0.1.8.dev0`（`uv lock --check` 一致）

发布 v0.1.8 时去后缀。

🤖 Generated with [Claude Code](https://claude.com/claude-code)