### PR TITLE
P16：发言权重 talkativeness + 手动调度档 schedule_mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,18 @@ Electron main (Node)  ─ spawn ─→  chahua-server (Python sidecar)
 - **`[[guest.extra_mcp_servers]]` 自动信任，persona sidecar `mcp.json` 走 trust 门**。前者用户手写=意图；后者可能 GitHub 导入任意可执行须 UI 勾选。同名房间级覆盖 persona。
 - **isolation 切换不自动迁移记忆**。`isolation` 决定茶客 cwd；切换后旧路径 `.agentao/memory.db` / `sessions/` 原样保留。
 
+### 发言权重与手动模式（P16）
+
+承重契约；完整 rationale / 反向评审溯源见 `docs/P16-发言权重与手动模式.md`，改不变量两处同步。
+
+- **`schedule_mode` 只换 auto-pick 第 3 档；`@mention` / `@broadcast` 在所有档下字面不变**。前两档是确定性路由（score=1.0），档无关、不打分、不吃 talkativeness。`manual` 档 `pick_next_speaker` 第 3 档恒返 `[]` + 零打分 LLM 调用（增量是成本不是行为，≈ `want_threshold=1.0` 但跳过 N 次打分）。
+- **调度档与 handoff / MTS 正交**。delegate/review/panel/MTS 跑 `run_pending_handoff` drain loop、不经 auto-pick，故 `manual` 房照常工作。
+- **`talkativeness` 仅作用 `scoring` 档 auto-pick 分数：`effective = clamp(base_score × talkativeness, 0, 1)`**。乘性（base=0 再高权重仍 0）；驱动阈值 + 排名 + envelope `data.scores`。**绝不**作用 `@`/broadcast/handoff/MTS/cooldown 门、**绝不**进打分 prompt（`scoring.py` 行为一字不动）。仅 `ScoreKind.SCORED` 被偏置（ERROR/COOLDOWN 原样）。
+- **talkativeness 默认 coalesce：`None`（未填）→`1.0`，`0.0`=合法哑茶客，禁 `or 1.0`**。use 点 `x if x is not None else 1.0`（与 permission/isolation 同坑）。范围 `[0.0,4.0]` + 拒非有限值（NaN/inf）—— TOML 允许 `nan` 字面量，`score×NaN=NaN` 会永久静默茶客且 `repr(nan)` 落盘。MVP 无 manifest 联动（manifest 是硬编码白名单非派生）。
+- **取证靠显式穿透序列化**。`ScoreResult.base_score`/`talkativeness` 仅载体；实时 `data.scores`（`score_to_dict`）只发 effective `score`；`record_scoring` entry 仅 SCORED 且 talk≠1.0 时补 `base_score`/`talkativeness` 两 key。`scoring_path` 增 `manual` 值，加字段/key 均不 bump `schema_version`。
+- **两旋钮走 `swap_room_config` 轻热替，不走 `_replace_session`**。声明性字段、不改 cwd/client/agent → 下一轮 pick 当场生效、不 cancel in-flight、不重建茶客。`schedule_mode` 经 `_make_orchestrator_config(overrides, *, schedule_mode=, explicit=)` 装配——`explicit`（SDK 入参）非空时**完全优先**、不被 `schedule_mode=` 覆盖；**不**经 `orchestrator_overrides` 数值表、**不**在 callsite 无脑 `dataclasses.replace`。talkativeness 经 `Orchestrator.update_talkativeness` 只刷 `_guests` 已存在 name（增删走 `_replace_session`）。
+- **配置闭环必经四点**（同 P6.3 `max_turns` 纪律）：`config.py` 定义+校验 → `session.py` 装配穿参 → `admin_room.py`/`admin_guest.py` mutator + `admin_toml.py` 回写（默认 `scoring`/`1.0` 不写盘，显式 `0.0` 保留）→ 本不变量。漏一点字段被静默吞。M2 UI（room checkbox / guest 0–4 滑杆）走 `update_room_schedule_mode` / `update_guest_talkativeness` inbound（轻热替 handler，**不** cancel/`_replace_session`），回显源是 room snapshot 的 `schedule_mode`（room 顶层）/ `talkativeness`（guest dict）。
+
 ### persona 包 manifest（P12）
 
 - **`persona.toml` 顶层 `schema_version` 必填且唯一合法值=1**。缺/≠1 → `PersonaManifestError`。跨版本兼容唯一锚点；加字段不 bump，破坏性变更才 bump。

--- a/app/renderer/events.js
+++ b/app/renderer/events.js
@@ -177,9 +177,13 @@ export const Inbound = Object.freeze({
   // 结构化 mutator（P4 详细设置 modal 用）。payload 见对应 chahua/server.py
   // _inbound_* —— spec=null 是合法 payload，语义"清整段，回房间默认"。
   UPDATE_ROOM_ORCHESTRATOR: "update_room_orchestrator",
+  // P16 房间调度档（scoring/manual）。轻热替：server swap_room_config，不重装 session。
+  UPDATE_ROOM_SCHEDULE_MODE: "update_room_schedule_mode",
   UPDATE_ROOM_LLM: "update_room_llm",
   UPDATE_GUEST_LLM: "update_guest_llm",
   UPDATE_GUEST_ISOLATION: "update_guest_isolation",
+  // P16 per-guest 发言权重（0–4 乘性偏置）。轻热替：不重建茶客。
+  UPDATE_GUEST_TALKATIVENESS: "update_guest_talkativeness",
   UPDATE_GUEST_EXTRA_MCP: "update_guest_extra_mcp",
   // persona 导入：本地文件夹（main 端 dialog 选目录后传 path）/ GitHub URL。
   // 成功 / 失败都走 NOTICE envelope 回报；前端再用 alert / status 显示。

--- a/app/renderer/guest_settings.js
+++ b/app/renderer/guest_settings.js
@@ -121,7 +121,12 @@ function renderSkills(skills) {
   }
 }
 
-function fillForm(g, roomDefaultModel) {
+// P16：talkativeness 缺省视为 1.0（snapshot 总是带值，这里兜底老 envelope）。
+function guestTalkativeness(g) {
+  return typeof g.talkativeness === "number" ? g.talkativeness : 1.0;
+}
+
+function fillForm(g, roomDefaultModel, scheduleMode) {
   $("edit-guest-title").textContent = `设置「${g.name}」`;
   $("edit-guest-persona-hint").textContent = `人格：${g.persona_rel || ""}`;
   $("edit-guest-workspace-hint").textContent = `工作目录：${g.workspace_path || ""}`;
@@ -133,6 +138,16 @@ function fillForm(g, roomDefaultModel) {
 
   setRadio("edit-guest-permission", g.permission || DEFAULT_PERMISSION);
   setRadio("edit-guest-isolation", g.isolation || "room");
+
+  // P16 发言权重滑杆：回显当前值 + 实时数字。manual 档下 auto-pick 不跑，权重空转 →
+  // 置灰（非承重 UX 提示，仍可拖，只是 hint 说明无效）。
+  const slider = $("edit-guest-talkativeness");
+  const out = $("edit-guest-talkativeness-value");
+  slider.value = String(guestTalkativeness(g));
+  out.textContent = Number(slider.value).toFixed(1);
+  const manual = scheduleMode === "manual";
+  slider.disabled = manual;
+  $("edit-guest-talkativeness-hint").classList.toggle("modal-hint-muted", manual);
 
   renderPersonaMcpList(g.persona_mcp_servers || []);
   renderRoomMcpList(g.room_mcp_servers || []);
@@ -167,6 +182,12 @@ function diffPayloads(g) {
     out.push({ type: Inbound.UPDATE_GUEST_ISOLATION, name: g.name, isolation: newIso });
   }
 
+  // P16 发言权重：slider 值 vs 旧值（容差防 0.1 step 浮点抖动）。
+  const newTalk = Number($("edit-guest-talkativeness").value);
+  if (Math.abs(newTalk - guestTalkativeness(g)) > 1e-9) {
+    out.push({ type: Inbound.UPDATE_GUEST_TALKATIVENESS, name: g.name, talkativeness: newTalk });
+  }
+
   const newMcp = readRoomMcpList();
   const oldMcp = g.room_mcp_servers || [];
   if (JSON.stringify(newMcp) !== JSON.stringify(oldMcp)) {
@@ -179,11 +200,16 @@ export function createGuestSettings({ isConnected, send, setStatus }) {
   const modal = $("edit-guest-modal");
   let openedGuest = null;
   let roomDefaultModel = null;
+  let scheduleMode = "scoring";
 
   renderPermissionRow();
   llmSection.bindModeChange();
   $("edit-guest-room-mcp-add").addEventListener("click", () => {
     appendRoomMcpRow($("edit-guest-room-mcp-list"));
+  });
+  // P16 滑杆拖动时实时刷新右侧数字。
+  $("edit-guest-talkativeness").addEventListener("input", (e) => {
+    $("edit-guest-talkativeness-value").textContent = Number(e.target.value).toFixed(1);
   });
 
   $("edit-guest-submit").addEventListener("click", () => {
@@ -210,13 +236,14 @@ export function createGuestSettings({ isConnected, send, setStatus }) {
   });
 
   return {
-    setSnapshot({ roomDefaultLlmModel }) {
+    setSnapshot({ roomDefaultLlmModel, scheduleMode: mode }) {
       roomDefaultModel = roomDefaultLlmModel || null;
+      scheduleMode = mode || "scoring";
     },
     open(g) {
       if (!isConnected()) return;
       openedGuest = g;
-      fillForm(g, roomDefaultModel);
+      fillForm(g, roomDefaultModel, scheduleMode);
       modal.hidden = false;
     },
   };

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -214,6 +214,15 @@
           </fieldset>
 
           <fieldset class="modal-fieldset">
+            <legend>调度模式</legend>
+            <label class="modal-checkbox">
+              <input id="edit-room-schedule-manual" type="checkbox">
+              <span>手动模式：茶客只在被 <code>@</code> 点名 / <code>@all</code> 时发言</span>
+            </label>
+            <div class="modal-hint">默认（不勾）= 意愿打分自发接话。手动模式关闭自发接话、省每条消息的打分开销；<code>@</code> 提及 / handoff / 托管会话不受影响。</div>
+          </fieldset>
+
+          <fieldset class="modal-fieldset">
             <legend>编排参数</legend>
             <div class="modal-hint">影响"由谁发言、连续几轮、什么时候等用户"。留空恢复默认。</div>
             <div class="modal-orch-grid">
@@ -361,6 +370,18 @@
           <fieldset class="modal-fieldset">
             <legend>权限</legend>
             <div class="modal-radio-row" id="edit-guest-permission-row"></div>
+          </fieldset>
+
+          <fieldset class="modal-fieldset">
+            <legend>发言权重 <code>talkativeness</code></legend>
+            <div class="modal-talk-row">
+              <input id="edit-guest-talkativeness" type="range" min="0" max="4" step="0.1" value="1">
+              <output id="edit-guest-talkativeness-value" class="modal-talk-value">1.0</output>
+            </div>
+            <div class="modal-hint" id="edit-guest-talkativeness-hint">
+              意愿打分时的乘性偏置：<code>1.0</code> 原样、<code>&lt;1</code> 高冷、<code>&gt;1</code> 爱抢、<code>0</code> 自发时哑。
+              只影响"自发接话"，不影响被 <code>@</code> 点名。手动模式下空转。
+            </div>
           </fieldset>
 
           <fieldset class="modal-fieldset">

--- a/app/renderer/renderer.js
+++ b/app/renderer/renderer.js
@@ -354,6 +354,7 @@ function renderSidebar(roomInfo) {
   });
   guestSettings.setSnapshot({
     roomDefaultLlmModel: roomInfo.room_default_llm?.model || null,
+    scheduleMode: roomInfo.schedule_mode || "scoring",
   });
   roomSettings.setSnapshot(roomInfo);
   sidebar.setUser({

--- a/app/renderer/room_settings.js
+++ b/app/renderer/room_settings.js
@@ -155,6 +155,11 @@ export function createRoomSettings({ isConnected, send, setStatus, openGuestSett
     if (orchestratorChanged(orch.overrides, snapshot.orchestrator, snapshot.orchestrator_overrides_keys)) {
       payloads.push({ type: Inbound.UPDATE_ROOM_ORCHESTRATOR, overrides: orch.overrides });
     }
+    // P16 调度档：checkbox → scoring/manual。轻热替，与编排参数同口径（server 不重装 session）。
+    const newMode = $("edit-room-schedule-manual").checked ? "manual" : "scoring";
+    if (newMode !== (snapshot.schedule_mode || "scoring")) {
+      payloads.push({ type: Inbound.UPDATE_ROOM_SCHEDULE_MODE, mode: newMode });
+    }
     if (scoringSection.changed(scoring.spec, snapshot.scoring_llm)) {
       payloads.push({ type: Inbound.UPDATE_ROOM_LLM, section: "scoring", spec: scoring.spec });
     }
@@ -177,6 +182,7 @@ export function createRoomSettings({ isConnected, send, setStatus, openGuestSett
         `话题：${snapshot.topic || "（无）"}  ·  规则与 name 改动请走"打开 raw room.toml"`;
 
       fillOrchestrator(snapshot.orchestrator, snapshot.orchestrator_overrides_keys);
+      $("edit-room-schedule-manual").checked = snapshot.schedule_mode === "manual";
 
       // 房间默认 LLM 自己的 "default" 模式 = 走 env 推断；label 顺手把 env 当前
       // 解析到的 model 露出来，便于用户判断 env 是否就绪。

--- a/app/renderer/styles/modal.css
+++ b/app/renderer/styles/modal.css
@@ -146,6 +146,33 @@
   gap: 16px;
 }
 .modal-radio-row .modal-radio { padding: 0; }
+/* P16 调度模式 checkbox —— 复用 modal-radio 的横排对齐。 */
+.modal-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #444;
+  padding: 3px 0;
+  cursor: pointer;
+}
+/* P16 发言权重滑杆行：range 占满 + 右侧固定宽数字。 */
+.modal-talk-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.modal-talk-row input[type="range"] { flex: 1; }
+.modal-talk-row input[type="range"]:disabled { opacity: 0.45; cursor: not-allowed; }
+.modal-talk-value {
+  min-width: 30px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  color: #444;
+}
+/* manual 档下权重空转 —— hint 灰一档提示无效。 */
+.modal-hint-muted { opacity: 0.5; }
 /* LLM 字段块 —— custom radio 选中时才展开，default 时折回（hidden 属性）。 */
 .modal-llm-fields { padding-left: 22px; margin-top: 4px; }
 .modal-llm-fields .modal-field { margin-bottom: 8px; }

--- a/chahua/_orchestrator_scoring.py
+++ b/chahua/_orchestrator_scoring.py
@@ -23,16 +23,19 @@ context 装配（``_build_context_for`` / ``_maybe_render_scoring_task_block`` /
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from typing import TYPE_CHECKING, Optional
 
 from .debug_recorder import (
     SCORING_PATH_BROADCAST,
+    SCORING_PATH_MANUAL,
     SCORING_PATH_MENTION,
     SCORING_PATH_SCORING,
     PickDebugMeta,
 )
 from .events import EnvelopeSink
 from .mentions import BROADCAST_TOKENS, iter_at_positions, matches_at
+from .orchestrator_config import SCHEDULE_MODE_MANUAL
 from .room import Message
 from .scoring import ScoreKind, ScoreResult
 from .task_rendering import wrap_current_task as _wrap_current_task
@@ -110,6 +113,17 @@ class ScoringOps:
                     threshold=None, scoring_path=SCORING_PATH_MENTION,
                 )
 
+        # P16 manual 档：auto-pick 第 3 档恒空、零打分 LLM 调用。前两档（``@`` /
+        # broadcast）已在上方处理、档无关；handoff / MTS 走 ``run_pending_handoff``
+        # drain loop、不经本函数，故 manual 房 delegate / 圆桌 / 托管会话照常。
+        # recorder 仍记一行（``scoring_path=manual``、``results=[]``），符合"每 pick
+        # 周期一行 turns.jsonl"。``respect_at_mention=False``（AI 接力）也命中这里 ——
+        # manual 下连自发接力都关。
+        if orch.config.schedule_mode == SCHEDULE_MODE_MANUAL:
+            return [], [], {}, PickDebugMeta(
+                threshold=None, scoring_path=SCORING_PATH_MANUAL,
+            )
+
         # 2) 并发打分（冷却中的茶客直接当 0 分，省 LLM 调用；busy 整段不进入两边任一
         # 桶 —— 与 scorables/cooled 是三档分流，bg run 跑完自然回到 scorables 池）
         scorables = [
@@ -148,10 +162,16 @@ class ScoringOps:
                 )
             )
         )
-        results = [r for r, _ in scored]
         prompts_by_guest: dict[str, Optional[str]] = {
             r.guest_name: p for r, p in scored if p is not None
         }
+        # P16 talkativeness 偏置：拿到打分**之后**乘性缩放 + reclamp。effective 驱动
+        # 阈值 / 排名 / envelope ``data.scores``（所见即所排）；base_score 留作取证载体。
+        # 乘性而非加性 —— base=0（话题无关）再高权重仍 0（"爱说话"≠"乱插话"）。只作用
+        # 本批 SCORED 结果；cooled（下方补）是 0 分占位、不偏置。
+        results: list[ScoreResult] = [
+            self._apply_talkativeness(r) for r, _ in scored
+        ]
 
         # 冷却中那些也填进 results 让 UI / recorder 看到"为什么没选他"。
         for name in cooled:
@@ -183,6 +203,27 @@ class ScoringOps:
         not_busy = [r for r in passed if r.guest_name not in current_busy]
         winners = [r.guest_name for r in not_busy[: orch.config.max_speakers_per_pick]]
         return winners, results, prompts_by_guest, debug_meta
+
+    def _apply_talkativeness(self, result: ScoreResult) -> ScoreResult:
+        """P16：对单条 SCORED 结果施加 per-guest talkativeness 乘性偏置 + reclamp [0,1]。
+
+        系数从 ``_GuestEntry.talkativeness`` 读（缺省 1.0）。``base_score`` 记偏置前的
+        原始 LLM 分、``talkativeness`` 记本次系数 —— 两者仅取证载体（实时 ``data.scores``
+        只发 effective ``score``）。1.0 严格 no-op（effective == base）。``gather`` 可能
+        产出 ``ERROR``（LLM 失败降级 0）—— 本守卫把**非 SCORED**（含 ERROR）原样返回、
+        不偏置，只对 SCORED 施加乘性系数。
+        """
+        if result.kind is not ScoreKind.SCORED:
+            return result
+        entry = self.orch._guests.get(result.guest_name)
+        talk = entry.talkativeness if entry is not None else 1.0
+        effective = max(0.0, min(1.0, result.score * talk))
+        return dataclasses.replace(
+            result,
+            score=effective,
+            base_score=result.score,
+            talkativeness=talk,
+        )
 
     async def score_one(
         self,

--- a/chahua/_server_helpers.py
+++ b/chahua/_server_helpers.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import Optional
 
 _log = logging.getLogger(__name__)
@@ -61,6 +62,24 @@ def require_list(data: dict, key: str, *, where: str) -> Optional[list]:
         _log.warning("ignoring %s: %s 必须是 list，收到 %r", where, key, type(v))
         return None
     return v
+
+
+def require_number(data: dict, key: str, *, where: str) -> Optional[float]:
+    """取数值字段（``int`` / ``float``）并 promote 到 ``float``；非数值 / 缺 → WARN + None。
+
+    ``bool`` 是 ``int`` 子类，显式剔除（``True`` 不该被当 1.0）。``NaN`` / ``±inf`` 也拒
+    —— Python ``json.loads`` 默认收 ``NaN`` / ``Infinity`` token，放进去会污染下游
+    （如 ``score × NaN = NaN`` 让茶客永久静默、``repr(nan)`` 还是合法 TOML 字面量会落盘）。
+    范围 / 业务校验留给下游 mutator —— 本层只挡 wire 类型 + 非有限值。
+    """
+    v = data.get(key)
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
+        _log.warning("ignoring %s: %s 必须是数值，收到 %r", where, key, type(v))
+        return None
+    if not math.isfinite(v):
+        _log.warning("ignoring %s: %s 必须是有限数值，收到 %r", where, key, v)
+        return None
+    return float(v)
 
 
 def check_optional_dict(data: dict, key: str, *, where: str) -> bool:

--- a/chahua/admin.py
+++ b/chahua/admin.py
@@ -49,6 +49,7 @@ from .admin_room import (  # noqa: F401
     delete_room,
     update_room_llm,
     update_room_orchestrator,
+    update_room_schedule_mode,
 )
 # 每位茶客的 mutator。
 from .admin_guest import (  # noqa: F401
@@ -59,6 +60,7 @@ from .admin_guest import (  # noqa: F401
     update_guest_isolation,
     update_guest_llm,
     update_guest_permission,
+    update_guest_talkativeness,
 )
 # USER.md / 头像 / raw room.toml 编辑入口。
 from .admin_user import (  # noqa: F401

--- a/chahua/admin_guest.py
+++ b/chahua/admin_guest.py
@@ -13,6 +13,7 @@ P6.x 重构：从 :mod:`chahua.admin` 抽出。本模块只动 ``[[guest]]`` 数
 from __future__ import annotations
 
 import logging
+import math
 from pathlib import Path
 from typing import Any, Callable, Literal, Optional, Sequence
 
@@ -26,6 +27,8 @@ from .admin_room import (
 from .admin_toml import GuestSnapshot
 from .config import (
     DEFAULT_ISOLATION,
+    TALKATIVENESS_MAX,
+    TALKATIVENESS_MIN,
     VALID_ISOLATION,
     _build_extra_mcp_servers,
     RoomConfig,
@@ -158,6 +161,40 @@ def update_guest_llm(
             cleaned.update(validated)  # type: ignore[typeddict-item]
         return cleaned
 
+    _mutate_guest_in_snapshot(snapshot, name=name, transform=_patch)
+    return _rewrite_and_validate(room_dir, snapshot, paths)
+
+
+def update_guest_talkativeness(
+    *, paths: Paths, room_dir: Path, name: str, talkativeness: float,
+) -> RoomConfig:
+    """改一位茶客的 ``talkativeness``（P16），返回新的 ``RoomConfig``。
+
+    范围 ``[TALKATIVENESS_MIN, TALKATIVENESS_MAX]`` **写盘前**校验（越界 →
+    :class:`RoomConfigError`，不靠"写盘再 reload 回滚"）。``1.0``（含未显式默认）走
+    "默认值不进 snapshot"约定 —— render 层只在 ``!= 1.0`` 时写盘；``0.0``（哑茶客）是
+    合法显式值，照写。名字不在册 → :class:`ValueError`。
+
+    本函数只动 ``room.toml``；生效靠调用方 ``swap_room_config`` 轻热替刷新
+    ``_GuestEntry.talkativeness``（不重建茶客 —— talkativeness 不改 cwd / client / agent）。
+    """
+    if not math.isfinite(talkativeness):
+        raise RoomConfigError(
+            f"talkativeness={talkativeness!r} 必须是有限数值"
+        )
+    if talkativeness < TALKATIVENESS_MIN or talkativeness > TALKATIVENESS_MAX:
+        raise RoomConfigError(
+            f"talkativeness={talkativeness!r} 越界，要求 "
+            f"[{TALKATIVENESS_MIN}, {TALKATIVENESS_MAX}]"
+        )
+
+    def _patch(g: GuestSnapshot) -> GuestSnapshot:
+        cleaned: GuestSnapshot = {k: v for k, v in g.items() if k != "talkativeness"}  # type: ignore[misc]
+        if talkativeness != 1.0:
+            cleaned["talkativeness"] = talkativeness
+        return cleaned
+
+    snapshot = _read_existing_for_mutate(room_dir, paths)
     _mutate_guest_in_snapshot(snapshot, name=name, transform=_patch)
     return _rewrite_and_validate(room_dir, snapshot, paths)
 

--- a/chahua/admin_room.py
+++ b/chahua/admin_room.py
@@ -38,6 +38,7 @@ from .config import (
     DEBUG_DEFAULT_MAX_TURNS,
     DEFAULT_ISOLATION,
     ORCH_FIELD_BOUNDS,
+    VALID_SCHEDULE_MODES,
     _build_orchestrator_overrides,
     DebugConfig,
     RoomConfig,
@@ -130,6 +131,10 @@ def _room_config_to_dict(rc: RoomConfig, paths: Paths) -> TomlSnapshot:
             g["isolation"] = gc.isolation
         if gc.summary:
             g["summary"] = gc.summary
+        # P16 talkativeness：默认（None 未填 / 1.0 no-op）不进 snapshot；合法显式 0.0
+        # （哑茶客）≠ 1.0 → 携带，round-trip 保住。
+        if gc.talkativeness is not None and gc.talkativeness != 1.0:
+            g["talkativeness"] = gc.talkativeness
         if gc.llm is not None:
             g.update(_llm_spec_to_dict(gc.llm))
         if gc.extra_mcp_servers:
@@ -140,6 +145,8 @@ def _room_config_to_dict(rc: RoomConfig, paths: Paths) -> TomlSnapshot:
         "topic": rc.topic,
         "rules": rc.rules,
         "user_md": rc.user_md_override,
+        # P16 schedule_mode：render 层只在 != "scoring" 时写盘，这里始终携带值即可。
+        "schedule_mode": rc.schedule_mode,
         "orchestrator_overrides": dict(rc.orchestrator_overrides),
         "room_llm": _llm_spec_to_dict(rc.room_llm) if rc.room_llm else None,
         "scoring": _llm_spec_to_dict(rc.scoring_llm) if rc.scoring_llm else None,
@@ -392,6 +399,27 @@ def update_room_orchestrator(
     validated = _build_orchestrator_overrides(overrides, toml_path=toml_path)
     snapshot = _read_existing_for_mutate(room_dir, paths)
     snapshot["orchestrator_overrides"] = validated
+    return _rewrite_and_validate(room_dir, snapshot, paths)
+
+
+def update_room_schedule_mode(
+    *, paths: Paths, room_dir: Path, mode: str,
+) -> RoomConfig:
+    """改 ``[room].schedule_mode``（P16），返回新的 ``RoomConfig``。
+
+    白名单 :data:`chahua.config.VALID_SCHEDULE_MODES` **写盘前**校验（暂缓的
+    ``round_robin`` / ``pooled`` 也在此被拒）。默认 ``"scoring"`` 走"默认值不进
+    snapshot"约定 —— render 层只在 ``!= "scoring"`` 时写盘，故设默认即清掉那行。
+
+    本函数只动 ``room.toml``；生效靠调用方 ``swap_room_config`` 轻热替
+    （声明性字段、不重建茶客）。
+    """
+    if mode not in VALID_SCHEDULE_MODES:
+        raise RoomConfigError(
+            f"schedule_mode={mode!r} 不在 {sorted(VALID_SCHEDULE_MODES)} 内"
+        )
+    snapshot = _read_existing_for_mutate(room_dir, paths)
+    snapshot["schedule_mode"] = mode
     return _rewrite_and_validate(room_dir, snapshot, paths)
 
 

--- a/chahua/admin_toml.py
+++ b/chahua/admin_toml.py
@@ -19,6 +19,7 @@ from typing import Any, Optional, Sequence, TypedDict
 from ._persist import write_text_atomic
 from .config import ORCH_FIELD_BOUNDS
 from .llm_spec import LLM_TOML_FIELDS, LLM_TOML_NUMERIC_FIELDS, LLMSpec
+from .orchestrator_config import SCHEDULE_MODE_SCORING
 from .permissions import DEFAULT_MODE
 
 
@@ -37,6 +38,7 @@ class GuestSnapshot(TypedDict, total=False):
     permission: str
     isolation: str
     summary: str  # P8.2-roster-a：一句话能力摘要；缺 / 空 = 不写
+    talkativeness: float  # P16 发言偏置；缺 / 等于默认 1.0 = 不写
     # LLM 四件套（all-or-nothing：写 model 才允许 base_url / api_key_env / temperature，
     # 详见 chahua.llm_spec.LLMSpec.from_toml 校验）。temperature 是 float（非字符串），
     # render 时走 scalar literal —— 见 _render_llm_field。
@@ -54,6 +56,7 @@ class TomlSnapshot(TypedDict, total=False):
     topic: str
     rules: str
     user_md: Optional[str]                       # [room].user_md；None / "" = 不写
+    schedule_mode: str                           # P16 [room].schedule_mode；"scoring"(默认)= 不写
     orchestrator_overrides: dict[str, Any]       # 空 dict = 不写编排字段（P4.0 消费）
     room_llm: Optional[dict]                     # None = 不写 [room.llm]（P4.9）
     scoring: Optional[dict]                      # None = 不写 [scoring]（P4.1）
@@ -64,7 +67,10 @@ class TomlSnapshot(TypedDict, total=False):
 
 # render 时认得的 guest 字段。
 _ALLOWED_GUEST_EMIT: frozenset[str] = (
-    frozenset({"name", "persona", "permission", "isolation", "summary", "extra_mcp_servers"})
+    frozenset({
+        "name", "persona", "permission", "isolation", "summary",
+        "talkativeness", "extra_mcp_servers",
+    })
     | frozenset(LLM_TOML_FIELDS)
 )
 
@@ -195,6 +201,12 @@ def _render_room_toml(snapshot: TomlSnapshot) -> str:
     if user_md:
         lines.append(f"user_md = {_toml_basic_string(user_md)}")
 
+    # P16 schedule_mode（[room] 标量字符串，非编排数值表）。仅非默认（"scoring"）时写 ——
+    # 默认房间结构化重写不塞噪声，用户写过的 "manual" 经 mutator round-trip 保得住。
+    schedule_mode = snapshot.get("schedule_mode")
+    if schedule_mode and schedule_mode != SCHEDULE_MODE_SCORING:
+        lines.append(f"schedule_mode = {_toml_basic_string(schedule_mode)}")
+
     # 编排参数走 [room] 段，按 ORCH_FIELD_BOUNDS 顺序写出（设计文档 §3 示例的顺序，
     # 用户读 toml 时编排参数总是连成一块好认）。snapshot 只携带用户实际设过的键 ——
     # 没设的不写，保留 OrchestratorConfig() 默认。
@@ -262,6 +274,12 @@ def _render_room_toml(snapshot: TomlSnapshot) -> str:
             lines.append(f"isolation  = {_toml_basic_string(str(g['isolation']))}")
         if g.get("summary"):
             lines.append(f"summary    = {_toml_basic_string(str(g['summary']))}")
+        # P16 talkativeness（snapshot 只在非默认 1.0 时携带，含合法显式 0.0）。
+        # float scalar literal（``_format_toml_scalar`` 走 repr）。
+        if "talkativeness" in g:
+            lines.append(
+                f"talkativeness = {_format_toml_scalar(float(g['talkativeness']))}"
+            )
         for key in LLM_TOML_FIELDS:
             if key in g:
                 lines.append(f"{key:<11}= {_render_llm_field(key, g[key])}")

--- a/chahua/config.py
+++ b/chahua/config.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import base64
+import math
 import tomllib
 from dataclasses import dataclass, field
 from functools import lru_cache
@@ -29,6 +30,10 @@ from typing import Any, Iterable, Literal, Optional
 
 from ._paths import Paths, resolve_under
 from .llm_spec import LLM_TOML_FIELDS, LLMSpec
+from .orchestrator_config import (
+    SCHEDULE_MODE_SCORING,
+    VALID_SCHEDULE_MODES,
+)
 from .permissions import DEFAULT_MODE, VALID_MODES, is_valid_mode
 
 
@@ -77,19 +82,31 @@ ORCH_FIELD_BOUNDS: dict[str, tuple[type, float, Optional[float]]] = {
     "onboarding_threshold": (int, 1, None),
 }
 
-# [room] 段允许的键 = 固定四件套 + 编排参数（派生自 ORCH_FIELD_BOUNDS）+ ``llm``
-# 子表（P4.9 起，房间默认 LLM 段，对应 toml 里的 ``[room.llm]`` dotted table）。
-# ``llm`` 是 dict 而非标量，平面 key 校验不限制其内部字段；具体字段走
-# :meth:`LLMSpec.from_toml`。
+# P16 ``[[guest]].talkativeness`` 范围。乘性偏置（``effective = clamp(base × talk, 0, 1)``）；
+# 0=自发时哑、1=原样（默认 / no-op）、>1=爱抢、4 是 sanity 上限防误填（0.0→4.0）。
+# **不进** ORCH_FIELD_BOUNDS —— 那是 [room] 编排数值表，talkativeness 是 per-guest。
+TALKATIVENESS_MIN: float = 0.0
+TALKATIVENESS_MAX: float = 4.0
+DEFAULT_TALKATIVENESS: float = 1.0
+
+# [room] 段允许的键 = 固定四件套 + ``schedule_mode``（P16 调度档）+ 编排参数（派生自
+# ORCH_FIELD_BOUNDS）+ ``llm`` 子表（P4.9 起，房间默认 LLM 段，对应 toml 里的
+# ``[room.llm]`` dotted table）。``llm`` 是 dict 而非标量，平面 key 校验不限制其内部
+# 字段；具体字段走 :meth:`LLMSpec.from_toml`。``schedule_mode`` 是字符串、走专用
+# 白名单校验（:data:`VALID_SCHEDULE_MODES`），**不混进 ORCH_FIELD_BOUNDS 数值表 /
+# orchestrator_overrides**（否则字符串塞进只遍历 ORCH_FIELD_BOUNDS 的
+# ``_build_orchestrator_overrides`` 会"白名单允许但被静默忽略"）。
 _ALLOWED_ROOM_KEYS: frozenset[str] = (
-    frozenset({"name", "topic", "rules", "user_md", "llm"})
+    frozenset({"name", "topic", "rules", "user_md", "llm", "schedule_mode"})
     | frozenset(ORCH_FIELD_BOUNDS)
 )
 # [[guest]] 段允许的键。LLM 四件套（model/base_url/api_key_env/temperature）的具体校验
-# 在 LLMSpec.from_toml；这里只是顶层白名单。
+# 在 LLMSpec.from_toml；这里只是顶层白名单。``talkativeness``（P16）是 per-guest 乘性
+# 发言偏置，范围校验走 :data:`TALKATIVENESS_MIN` / :data:`TALKATIVENESS_MAX`。
 _ALLOWED_GUEST_KEYS: frozenset[str] = frozenset(
     {
         "name", "persona", "permission", "isolation", "summary",
+        "talkativeness",
         "model", "base_url", "api_key_env", "temperature",
         "extra_mcp_servers",
     }
@@ -176,6 +193,13 @@ class GuestConfig:
     onboarding 的 ``<room>`` 块「在场」行据此渲成带摘要的花名册，让茶客分工时看得见
     别的茶客擅长什么。缺即 ``None``，「在场」行优雅降级为只列名字。"""
 
+    talkativeness: Optional[float] = None
+    """``[[guest]].talkativeness`` —— P16 per-guest 乘性发言偏置（``scoring`` 档 auto-pick
+    专用）。``None`` = **未显式填**（装配 / 热替时 coalesce 到 :data:`DEFAULT_TALKATIVENESS`
+    = 1.0）；``0.0`` = 合法显式（自发时哑茶客）。消费侧严禁 ``x or 1.0``（会把 ``0.0``
+    吞成默认）—— 用 ``x if x is not None else 1.0``，与 permission / isolation 的
+    "禁 ``or DEFAULT_MODE``"同坑。范围 ``[0.0, 4.0]`` 在解析期校验。"""
+
     extra_mcp_servers: Optional[dict[str, dict[str, Any]]] = None
     """房间级 inline MCP servers（``[[guest.extra_mcp_servers]]`` 数组表解析结果）。
 
@@ -240,7 +264,17 @@ class RoomConfig:
     """``[room]`` 段里出现的编排参数（``want_threshold`` / ``max_consecutive_ai_turns`` /
     ``speaker_cooldown_turns`` / ``onboarding_threshold``）。**只装载用户实际写了的键** ——
     没写 = 不在 dict 里；session 装配时 patch 到 :class:`OrchestratorConfig()` 默认上。
-    这样回写 toml 时也只回写用户填的那几个，不会把"默认值"硬塞进文件。"""
+    这样回写 toml 时也只回写用户填的那几个，不会把"默认值"硬塞进文件。
+
+    ``schedule_mode`` **不在这里** —— 它是字符串、走 :attr:`schedule_mode` 专用字段，
+    经 :func:`chahua.session._make_orchestrator_config` 的 ``schedule_mode=`` 形参穿进
+    ``OrchestratorConfig``，不混 orchestrator_overrides 数值表（见该字段 / P16 不变量）。"""
+
+    schedule_mode: str = SCHEDULE_MODE_SCORING
+    """``[room].schedule_mode``（P16）。专用字段，**非** orchestrator_overrides ——
+    解析期已对 :data:`VALID_SCHEDULE_MODES` 严格校验。装配 / 热替经
+    ``_make_orchestrator_config(..., schedule_mode=rc.schedule_mode)`` 写进
+    ``OrchestratorConfig.schedule_mode``；SDK 显式 ``explicit`` 入参完全优先、不被它覆盖。"""
 
     room_llm: Optional[LLMSpec] = None
     """``[room.llm]`` 段解析结果（P4.9 起）；缺 = 走 env 推断
@@ -325,6 +359,10 @@ def _build(
         room_raw, toml_path=toml_path
     )
 
+    schedule_mode = _build_schedule_mode(
+        room_raw.get("schedule_mode"), toml_path=toml_path
+    )
+
     # P4.9：``[room.llm]`` 走 [room] 下的 dotted-table 子表。tomllib 解析后是
     # ``room_raw["llm"] = {...}``；缺即 None，让装配层 fall back 到 env。
     room_llm = _build_room_llm_section(
@@ -351,6 +389,7 @@ def _build(
         guests=guests,
         user_md_override=user_md_override,
         orchestrator_overrides=orchestrator_overrides,
+        schedule_mode=schedule_mode,
         room_llm=room_llm,
         scoring_llm=scoring_llm,
         summary_llm=summary_llm,
@@ -479,6 +518,65 @@ def _build_orchestrator_overrides(
             )
         out[key] = value
     return out
+
+
+def _build_schedule_mode(raw: Any, *, toml_path: Path) -> str:
+    """解析 ``[room].schedule_mode``（P16）。缺 → 默认 ``"scoring"``。
+
+    严格白名单 :data:`VALID_SCHEDULE_MODES`。暂缓的 ``round_robin`` / ``pooled`` 给
+    "暂缓 / 未实现"定向 hint（与拼错区分），其它非法值列允许集。``round_trip`` 这类
+    纯 typo 走"拼错"分支。
+    """
+    if raw is None:
+        return SCHEDULE_MODE_SCORING
+    if not isinstance(raw, str):
+        raise RoomConfigError(
+            f"{toml_path}: [room].schedule_mode 必须是字符串，得到 "
+            f"{type(raw).__name__}"
+        )
+    value = raw.strip()
+    if value in VALID_SCHEDULE_MODES:
+        return value
+    if value in {"round_robin", "pooled"}:
+        raise RoomConfigError(
+            f"{toml_path}: [room].schedule_mode={value!r} 暂未实现（P16 暂缓）。"
+            f"当前支持：{sorted(VALID_SCHEDULE_MODES)}"
+        )
+    raise RoomConfigError(
+        f"{toml_path}: [room].schedule_mode={value!r} 非法（拼写错误？）。"
+        f"允许：{sorted(VALID_SCHEDULE_MODES)}"
+    )
+
+
+def _build_talkativeness(raw: Any, *, label: str, toml_path: Path) -> Optional[float]:
+    """解析 ``[[guest]].talkativeness``（P16）。缺 → ``None``（未显式选，消费侧 coalesce
+    到 1.0）。
+
+    bool 先剔（``True`` 是 int 子类，别被当 1.0）；``int`` 向 ``float`` promote（TOML
+    ``2`` → ``2.0``）；范围 ``[TALKATIVENESS_MIN, TALKATIVENESS_MAX]`` 越界 raise。
+    ``0.0`` 是合法显式值（哑茶客），不被当"缺省"。
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise RoomConfigError(
+            f"{toml_path}: {label} talkativeness 必须是数值，得到 "
+            f"{type(raw).__name__}"
+        )
+    value = float(raw)
+    # NaN / ±inf 拒 —— TOML 允许 ``nan`` / ``inf`` 字面量，但放进打分会让
+    # ``score × NaN = NaN``（茶客永久静默）；非有限值不是合法权重。先于范围判
+    # （``nan < MIN`` / ``nan > MAX`` 都是 False 会漏过区间检查）。
+    if not math.isfinite(value):
+        raise RoomConfigError(
+            f"{toml_path}: {label} talkativeness={raw!r} 必须是有限数值"
+        )
+    if value < TALKATIVENESS_MIN or value > TALKATIVENESS_MAX:
+        raise RoomConfigError(
+            f"{toml_path}: {label} talkativeness={raw!r} 越界，要求 "
+            f"[{TALKATIVENESS_MIN}, {TALKATIVENESS_MAX}]"
+        )
+    return value
 
 
 def _build_extra_mcp_servers(
@@ -671,6 +769,12 @@ def _build_guests(
             toml_path=toml_path,
         )
 
+        talkativeness = _build_talkativeness(
+            g.get("talkativeness"),
+            label=f"[[guest]] {name!r}",
+            toml_path=toml_path,
+        )
+
         out.append(
             GuestConfig(
                 name=name,
@@ -680,6 +784,7 @@ def _build_guests(
                 llm=guest_llm,
                 extra_mcp_servers=extra_mcp,
                 summary=summary or None,
+                talkativeness=talkativeness,
             )
         )
 

--- a/chahua/debug_recorder.py
+++ b/chahua/debug_recorder.py
@@ -47,7 +47,7 @@ from .events import (
     STATUS_OK,
     now_ms,
 )
-from .scoring import ScoreResult
+from .scoring import ScoreKind, ScoreResult
 
 _log = logging.getLogger(__name__)
 
@@ -62,6 +62,9 @@ SCORING_PATH_MENTION: str = "mention"
 """单 ``@`` 路由（results 中仅命中那位 ``kind="mention"``）。"""
 SCORING_PATH_BROADCAST: str = "broadcast"
 """``@all`` / ``@所有人``（results 中所有 guest 都是 ``kind="mention"``）。"""
+SCORING_PATH_MANUAL: str = "manual"
+"""P16 ``schedule_mode=manual``：auto-pick 第 3 档恒空、零打分。多为空 turn
+（``scoring.results=[]``）但仍按"每 pick 周期一行 turns.jsonl"各记一行。"""
 SCORING_PATH_HANDOFF_DELEGATE: str = "handoff_delegate"
 """P7.1 显式 delegate 指派路径（drain loop 跑队列）。"""
 SCORING_PATH_HANDOFF_REVIEW: str = "handoff_review"
@@ -76,6 +79,7 @@ VALID_SCORING_PATHS: frozenset[str] = frozenset(
         SCORING_PATH_SCORING,
         SCORING_PATH_MENTION,
         SCORING_PATH_BROADCAST,
+        SCORING_PATH_MANUAL,
         SCORING_PATH_HANDOFF_DELEGATE,
         SCORING_PATH_HANDOFF_REVIEW,
         SCORING_PATH_HANDOFF_PANEL,
@@ -312,6 +316,17 @@ class TurnRecorder:
                     "kind": result.kind.value,
                     "raw": result.raw or "",
                 }
+                # P16 取证显式穿透：``score`` 是 effective（已偏置），实时 envelope
+                # ``data.scores`` 也只发 effective。仅 SCORED 且 talkativeness≠1.0
+                # 时补 ``base_score`` + ``talkativeness`` 落 jsonl —— 这才是"看得到
+                # raw×talk"的真正落点（加 dataclass 字段≠取证完成）。talk=1.0 是
+                # no-op（base==score），省略保 entry 精简。
+                if (
+                    result.kind is ScoreKind.SCORED
+                    and result.talkativeness != 1.0
+                ):
+                    entry["base_score"] = result.base_score
+                    entry["talkativeness"] = result.talkativeness
                 prompt_file = self._write_prompt_file(
                     f"prompts/{turn_id}/scoring_{result.guest_name}.txt",
                     prompt or "",

--- a/chahua/orchestrator.py
+++ b/chahua/orchestrator.py
@@ -84,6 +84,11 @@ __all__ = ["Orchestrator", "OrchestratorConfig"]
 class _GuestEntry:
     guest: TeaGuest
     persona_md: str
+    talkativeness: float = 1.0
+    """P16 per-guest 乘性发言偏置（``scoring`` 档 auto-pick 用）。装配期由
+    ``register(*, talkativeness=)`` 注入（已 coalesce 过 ``None``→1.0）；热替由
+    ``update_talkativeness`` 原地刷。1.0=no-op。读点见
+    :meth:`ScoringOps.pick_next_speaker` scoring 子分支。"""
 
 
 # ── 编排器 ───────────────────────────────────────────────────────────────────
@@ -198,13 +203,34 @@ class Orchestrator:
 
     # ── 注册 / 信息 ────────────────────────────────────────────────────
 
-    def register(self, guest: TeaGuest, persona_md: str) -> None:
-        """加入一位茶客。同名重复注册抛错。"""
+    def register(
+        self, guest: TeaGuest, persona_md: str, *, talkativeness: float = 1.0,
+    ) -> None:
+        """加入一位茶客。同名重复注册抛错。
+
+        ``talkativeness``（P16）= per-guest 乘性发言偏置，调用方（``session.py``）已
+        coalesce 过 ``None``→1.0；默认 1.0 让裸构 / 旧测试夹具零改。
+        """
         if guest.name in self._guests:
             raise ValueError(f"茶客 {guest.name!r} 已经注册过")
-        self._guests[guest.name] = _GuestEntry(guest=guest, persona_md=persona_md)
+        self._guests[guest.name] = _GuestEntry(
+            guest=guest, persona_md=persona_md, talkativeness=talkativeness,
+        )
         self.room.add_participant(guest.name)
         self._renderer.invalidate_display_cache()
+
+    def update_talkativeness(self, by_name: dict[str, float]) -> None:
+        """P16 轻热替：刷新已注册茶客的 ``talkativeness``（``swap_room_config`` 末尾调）。
+
+        **只更新当前 ``_guests`` 中已存在的 name** —— 缺失 / 新增茶客不在轻热替职责内
+        （茶客增删改 agent 实例，走 ``server._replace_session`` 重建）。原地改可变
+        ``_GuestEntry`` 字段，不重建 → 茶客 agentao 实例 / 进程内对话窗口 / 记忆全不动，
+        下一轮打分读新权重。
+        """
+        for name, value in by_name.items():
+            entry = self._guests.get(name)
+            if entry is not None:
+                entry.talkativeness = value
 
     def set_config(self, config: OrchestratorConfig) -> None:
         """热替换编排参数 —— 同步更新 Orchestrator 自身 + 内嵌 ContextRenderer 的 ref。

--- a/chahua/orchestrator_config.py
+++ b/chahua/orchestrator_config.py
@@ -9,9 +9,28 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 
+# P16 调度档取值（``[room].schedule_mode``）。``scoring``=默认意愿打分自发接话；
+# ``manual``=auto-pick 恒空、零打分 LLM 调用（只 @/broadcast/handoff/MTS 能让茶客说话）。
+# ``round_robin`` / ``pooled`` 设计上暂缓（docs/P16 §暂缓事项），不入白名单。
+# 常量住此模块（``OrchestratorConfig`` 字段默认 + config.py 校验 + 调度层比较三处共享），
+# 与 ``OrchestratorConfig`` 同生命周期、不引循环 import（本模块仅依赖 ``dataclasses``）。
+SCHEDULE_MODE_SCORING: str = "scoring"
+SCHEDULE_MODE_MANUAL: str = "manual"
+VALID_SCHEDULE_MODES: frozenset[str] = frozenset(
+    {SCHEDULE_MODE_SCORING, SCHEDULE_MODE_MANUAL}
+)
+
+
 @dataclass(frozen=True)
 class OrchestratorConfig:
     """房间编排参数。字段对应 ``room.toml`` ``[room]`` 段（P2 才会真读 toml）。"""
+
+    schedule_mode: str = SCHEDULE_MODE_SCORING
+    """P16 房间调度档。``scoring``（默认）= 意愿打分自发接话；``manual`` =
+    ``pick_next_speaker`` auto-pick 第 3 档恒返 ``[]``、零打分 —— 只有 ``@`` /
+    broadcast / handoff / MTS 能让茶客说话。**只换 auto-pick 这一档**：前两档（``@`` 路由）
+    与 handoff / MTS（走 ``run_pending_handoff`` drain loop）档无关、字面不变。
+    白名单 :data:`VALID_SCHEDULE_MODES` 严格校验在 ``config.py``。"""
 
     want_threshold: float = 0.45
     """打分 ≥ 此值才允许发言。0.55 起步时招呼/中性话题全员低于阈值导致冷场（实测），

--- a/chahua/scoring.py
+++ b/chahua/scoring.py
@@ -56,9 +56,23 @@ class ScoreResult:
 
     guest_name: str
     score: float
+    """**最终生效**分数。P16 ``scoring`` 档下 = ``clamp(base_score × talkativeness, 0, 1)``；
+    其它 kind / talkativeness=1.0 时 = 原始分。驱动阈值比较 / 排名 / envelope
+    ``data.scores``（所见即所排）。"""
+
     kind: ScoreKind = ScoreKind.SCORED
     raw: str = ""
     """LLM 原始文本（仅 ``kind=SCORED`` 时有值），调试用。"""
+
+    base_score: float = 0.0
+    """P16 talkativeness 偏置**前**的原始 LLM 分（仅 ``kind=SCORED`` 偏置路径有意义；
+    其它 kind 留默认 0.0）。**仅取证载体** —— 不自动序列化：实时 envelope ``data.scores``
+    只发 :attr:`score`（effective），要看 raw×talk 须 ``debug_recorder.record_scoring``
+    显式补 key（P16 不变量"加 dataclass 字段≠取证完成"）。"""
+
+    talkativeness: float = 1.0
+    """P16 本次施加的乘性系数（仅 ``kind=SCORED`` 偏置路径有意义）。与 :attr:`base_score`
+    同为取证载体；前端可据 base×talk 复原排名因果。"""
 
 
 # ── prompt ───────────────────────────────────────────────────────────────────

--- a/chahua/server.py
+++ b/chahua/server.py
@@ -85,8 +85,10 @@ from .server_inbound_admin import (
     INBOUND_UPDATE_GUEST_ISOLATION,
     INBOUND_UPDATE_GUEST_LLM,
     INBOUND_UPDATE_GUEST_PERMISSION,
+    INBOUND_UPDATE_GUEST_TALKATIVENESS,
     INBOUND_UPDATE_ROOM_LLM,
     INBOUND_UPDATE_ROOM_ORCHESTRATOR,
+    INBOUND_UPDATE_ROOM_SCHEDULE_MODE,
 )
 from .server_inbound_io import (
     INBOUND_CHECK_PERSONA_UPDATES,
@@ -1389,9 +1391,11 @@ _INBOUND_ROUTES: dict[str, str] = {
     INBOUND_CREATE_ROOM: "admin._inbound_create_room",
     INBOUND_DELETE_ROOM: "admin._inbound_delete_room",
     INBOUND_UPDATE_ROOM_ORCHESTRATOR: "admin._inbound_update_room_orchestrator",
+    INBOUND_UPDATE_ROOM_SCHEDULE_MODE: "admin._inbound_update_room_schedule_mode",
     INBOUND_UPDATE_ROOM_LLM: "admin._inbound_update_room_llm",
     INBOUND_UPDATE_GUEST_LLM: "admin._inbound_update_guest_llm",
     INBOUND_UPDATE_GUEST_ISOLATION: "admin._inbound_update_guest_isolation",
+    INBOUND_UPDATE_GUEST_TALKATIVENESS: "admin._inbound_update_guest_talkativeness",
     INBOUND_UPDATE_GUEST_EXTRA_MCP: "admin._inbound_update_guest_extra_mcp",
     # settings slot：USER.md / 房间 toml / 用户头像。
     INBOUND_UPDATE_USER_MD: "settings._inbound_update_user_md",

--- a/chahua/server_inbound_admin.py
+++ b/chahua/server_inbound_admin.py
@@ -19,6 +19,7 @@ from ._server_helpers import (
     check_optional_dict,
     require_bool,
     require_list,
+    require_number,
     require_str,
 )
 from .events import EnvelopeSink, NOTICE_LEVEL_ERROR
@@ -35,9 +36,11 @@ INBOUND_SET_PERSONA_MCP_TRUST = "set_persona_mcp_trust"
 INBOUND_CREATE_ROOM = "create_room"
 INBOUND_DELETE_ROOM = "delete_room"
 INBOUND_UPDATE_ROOM_ORCHESTRATOR = "update_room_orchestrator"
+INBOUND_UPDATE_ROOM_SCHEDULE_MODE = "update_room_schedule_mode"
 INBOUND_UPDATE_ROOM_LLM = "update_room_llm"
 INBOUND_UPDATE_GUEST_LLM = "update_guest_llm"
 INBOUND_UPDATE_GUEST_ISOLATION = "update_guest_isolation"
+INBOUND_UPDATE_GUEST_TALKATIVENESS = "update_guest_talkativeness"
 INBOUND_UPDATE_GUEST_EXTRA_MCP = "update_guest_extra_mcp"
 
 
@@ -191,6 +194,64 @@ class AdminHandlers:
             return
         self.server._session.swap_room_config(new_rc)
         _log.info("update_room_orchestrator: %r", overrides)
+        self.server._emit_room_snapshot(sink)
+
+    def _update_room_schedule_mode(
+        self, *, mode: str, sink: EnvelopeSink
+    ) -> None:
+        """改 ``[room].schedule_mode`` + 轻热替 ``orchestrator.config`` + 重发 snapshot（P16）。
+
+        与 :meth:`_update_room_orchestrator` 同口径走 :meth:`RoomSession.swap_room_config`
+        一次 attribute swap —— schedule_mode 是声明性字段（``Orchestrator`` 热循环 live
+        读 ``self.config.schedule_mode``），不改 cwd / client / agent，**不 cancel
+        in-flight、不 `_replace_session`**，下一轮 pick 当场生效。校验失败回
+        ``admin.update_room_schedule_mode`` 那条路径，磁盘旧 bytes 已回滚、session 不动。
+        """
+        room_dir = self.server._session.room_config.room_dir
+        try:
+            new_rc = admin.update_room_schedule_mode(
+                paths=self.server._paths, room_dir=room_dir, mode=mode
+            )
+        except Exception as e:
+            _log.exception("update_room_schedule_mode: mode=%r 失败", mode)
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"调度模式未生效：{e}"
+            )
+            self.server._emit_room_snapshot(sink)
+            return
+        self.server._session.swap_room_config(new_rc)
+        _log.info("update_room_schedule_mode: %r", mode)
+        self.server._emit_room_snapshot(sink)
+
+    def _update_guest_talkativeness(
+        self, *, name: str, talkativeness: float, sink: EnvelopeSink
+    ) -> None:
+        """改一位茶客的 ``talkativeness`` + 轻热替 + 重发 snapshot（P16）。
+
+        **首个走轻热替的 guest 设置** —— permission / isolation / LLM 改 agent 必重建，
+        talkativeness 不改 cwd / client / agent，只是打分后处理的乘性系数。走
+        :meth:`RoomSession.swap_room_config`（末尾刷新 ``_GuestEntry.talkativeness``）——
+        **不 cancel in-flight、不 `_replace_session`**，下一轮打分读新权重。校验失败回
+        ``admin.update_guest_talkativeness`` 那条路径，磁盘旧 bytes 已回滚、session 不动。
+        """
+        room_dir = self.server._session.room_config.room_dir
+        try:
+            new_rc = admin.update_guest_talkativeness(
+                paths=self.server._paths, room_dir=room_dir,
+                name=name, talkativeness=talkativeness,
+            )
+        except Exception as e:
+            _log.exception(
+                "update_guest_talkativeness: name=%r talkativeness=%r 失败",
+                name, talkativeness,
+            )
+            self.server._emit_notice(
+                sink, level=NOTICE_LEVEL_ERROR, text=f"发言权重未生效：{e}"
+            )
+            self.server._emit_room_snapshot(sink)
+            return
+        self.server._session.swap_room_config(new_rc)
+        _log.info("update_guest_talkativeness: %r → %r", name, talkativeness)
         self.server._emit_room_snapshot(sink)
 
     def _update_room_llm(
@@ -473,6 +534,33 @@ class AdminHandlers:
         # 不 cancel inflight —— 编排参数走 swap_room_config 热替 self.config，下一轮
         # 迭代当场生效，无需打断当前发言 / 评分。
         self._update_room_orchestrator(overrides=overrides, sink=sink)
+
+    async def _inbound_update_room_schedule_mode(
+        self, data: dict, sink: EnvelopeSink
+    ) -> None:
+        mode = require_str(data, "mode", where=INBOUND_UPDATE_ROOM_SCHEDULE_MODE)
+        if mode is None:
+            return
+        # P16 轻热替：schedule_mode 走 swap_room_config 热替 self.config，不 cancel
+        # in-flight、不 _replace_session。白名单校验在 admin 层。
+        self._update_room_schedule_mode(mode=mode, sink=sink)
+
+    async def _inbound_update_guest_talkativeness(
+        self, data: dict, sink: EnvelopeSink
+    ) -> None:
+        name = require_str(data, "name", where=INBOUND_UPDATE_GUEST_TALKATIVENESS)
+        if name is None:
+            return
+        talkativeness = require_number(
+            data, "talkativeness", where=INBOUND_UPDATE_GUEST_TALKATIVENESS
+        )
+        if talkativeness is None:
+            return
+        # P16 轻热替：talkativeness 不改 agent，走 swap_room_config 刷新 _GuestEntry，
+        # 不 cancel in-flight、不 _replace_session。范围校验在 admin 层。
+        self._update_guest_talkativeness(
+            name=name, talkativeness=talkativeness, sink=sink
+        )
 
     async def _inbound_update_room_llm(
         self, data: dict, sink: EnvelopeSink

--- a/chahua/server_room_snapshot.py
+++ b/chahua/server_room_snapshot.py
@@ -193,6 +193,10 @@ def emit_room_info(server: "ChahuaServer", sink: EnvelopeSink) -> None:
             "name": gc.name,
             "permission": gc.permission,
             "isolation": gc.isolation,
+            # P16 发言偏置：默认 1.0 也带（前端滑杆要回显）。``None`` 未填 → 1.0。
+            "talkativeness": (
+                gc.talkativeness if gc.talkativeness is not None else 1.0
+            ),
             "workspace_path": str(workspace_path),
             "avatar_data_uri": gc.read_avatar_data_uri(),
             "persona_rel": persona_rel,
@@ -239,6 +243,9 @@ def emit_room_info(server: "ChahuaServer", sink: EnvelopeSink) -> None:
                     server._session.orchestrator.config
                 ),
                 "orchestrator_overrides_keys": sorted(rc.orchestrator_overrides),
+                # P16 房间调度档（``scoring`` / ``manual``）—— room 设置 checkbox 回显。
+                # 取 effective（orchestrator.config）与 ``orchestrator`` 字段同源真理。
+                "schedule_mode": server._session.orchestrator.config.schedule_mode,
                 # 房间级 LLM section：与 guests[].llm 同构。
                 # ``source`` 是 "room" 表示 [scoring]/[summary] 段在 toml 里有写；
                 # "default" 表示该段缺失走的是房间默认。

--- a/chahua/session.py
+++ b/chahua/session.py
@@ -28,6 +28,7 @@ from .llm_spec import LLMSpec, build_client
 from .message_artifacts import MessageArtifactRegistry
 from . import persona_summary
 from .orchestrator import Orchestrator, OrchestratorConfig
+from .orchestrator_config import SCHEDULE_MODE_SCORING
 from .persona_assets import discover_assets, persona_relative
 from .room import Room
 from .scoring import IntentScorer
@@ -290,11 +291,26 @@ class RoomSession:
 
         **只适合编排参数 / 用户配置之类的"声明性"字段更新**；茶客增减 / persona 切换 /
         permission 改这些需要重建 ``TeaGuest`` 的，仍走 ``server._replace_session``。
+
+        P16：``schedule_mode`` 经 ``_make_orchestrator_config(..., schedule_mode=)`` 进
+        ``OrchestratorConfig``（无 explicit，照常用 ``new_rc.schedule_mode``）；
+        per-guest ``talkativeness`` 不在 ``OrchestratorConfig`` 里，末尾单独刷
+        ``_GuestEntry.talkativeness`` —— **只更新当前 ``_guests`` 中已存在的 name**，
+        缺失 / 新增茶客不在轻热替职责内（茶客增删改 agent，走 ``_replace_session``）。
         """
         object.__setattr__(self, "room_config", new_rc)
         self.orchestrator.set_config(
-            _make_orchestrator_config(new_rc.orchestrator_overrides)
+            _make_orchestrator_config(
+                new_rc.orchestrator_overrides,
+                schedule_mode=new_rc.schedule_mode,
+            )
         )
+        self.orchestrator.update_talkativeness({
+            gc.name: (
+                gc.talkativeness if gc.talkativeness is not None else 1.0
+            )
+            for gc in new_rc.guests
+        })
 
 
 def _resolve_room_default_spec(room_config: RoomConfig) -> LLMSpec:
@@ -321,18 +337,27 @@ def _resolve_room_default_spec(room_config: RoomConfig) -> LLMSpec:
 
 
 def _make_orchestrator_config(
-    overrides: dict[str, Any], *, explicit: Optional[OrchestratorConfig] = None,
+    overrides: dict[str, Any],
+    *,
+    schedule_mode: str = SCHEDULE_MODE_SCORING,
+    explicit: Optional[OrchestratorConfig] = None,
 ) -> OrchestratorConfig:
-    """显式 SDK 入参优先；其次 patch room.toml [room] 编排字段到默认上；都没有走默认。
+    """显式 SDK 入参优先；其次 patch room.toml [room] 编排字段 + schedule_mode 到默认上。
 
     `build_room_session` 与 `RoomSession.swap_room_config` 共用 —— 单点保证装配期 vs
     热更新期 走同一 OrchestratorConfig 派生口径。
+
+    P16 ``schedule_mode``：经专用形参穿进，**不**混 ``overrides`` 数值表。``explicit``
+    不为 None（SDK 嵌入入参）时**完全优先**、自带 schedule_mode、不被本形参覆盖 ——
+    守 P15 起的"显式 SDK 入参优先"契约。只有无 explicit 的正常 server / CLI 路径才把
+    ``schedule_mode`` 写进 ``OrchestratorConfig``。``swap_room_config`` 无 explicit，
+    传 ``new_rc.schedule_mode``。
     """
     if explicit is not None:
         return explicit
-    if overrides:
-        return dataclasses.replace(OrchestratorConfig(), **overrides)
-    return OrchestratorConfig()
+    fields: dict[str, Any] = dict(overrides)
+    fields["schedule_mode"] = schedule_mode
+    return dataclasses.replace(OrchestratorConfig(), **fields)
 
 
 def discover_rooms(paths: Paths) -> list[dict]:
@@ -468,7 +493,9 @@ def build_room_session(
     guests = [g for g, _ in guest_entries]
 
     effective_orch_config = _make_orchestrator_config(
-        room_config.orchestrator_overrides, explicit=orchestrator_config
+        room_config.orchestrator_overrides,
+        schedule_mode=room_config.schedule_mode,
+        explicit=orchestrator_config,
     )
 
     # P8.2-roster：花名册摘要三级解析 —— 手写 [[guest]].summary（roster-a）→ 中央
@@ -506,8 +533,16 @@ def build_room_session(
         # （后者已 mkdir 兜底）；这里再 helper 一次取 Path 是幂等的。
         share_dir=ensure_room_share_dir(room_config.room_dir),
     )
-    for guest, persona_md in guest_entries:
-        orchestrator.register(guest, persona_md)
+    # P16：register 同步注入 per-guest talkativeness。``room_config.guests`` 与
+    # ``guest_entries`` 同序（都由 _build_guests 按 toml [[guest]] 顺序构造）。
+    # ``is not None`` coalesce —— 显式 0.0（哑茶客）不被 ``or 1.0`` 吞。
+    for gc, (guest, persona_md) in zip(room_config.guests, guest_entries):
+        orchestrator.register(
+            guest, persona_md,
+            talkativeness=(
+                gc.talkativeness if gc.talkativeness is not None else 1.0
+            ),
+        )
 
     # P8.3：给每位茶客的 transport 注入托管会话 propose 拦截 hook（docs §5.1）。
     # 非托管房间 hook 命中即返 False、行为不变；MTS 内管理者的 delegate / panel

--- a/docs/P16-发言权重与手动模式.md
+++ b/docs/P16-发言权重与手动模式.md
@@ -1,0 +1,262 @@
+# P16：发言权重与手动模式 —— 茶客 `talkativeness` + 房间 `manual` 档
+
+> 来源：`docs/研究-同类项目与演进方向.md` §四.2「调度体验：小步增强」。经一轮**反向评审**(对照现有 `@mention` / task goal / handoff 调度面) + 一轮**代码扣证**(串接矛盾 / 取证穿透 / 生效路径)收敛定稿。
+>
+> **本文档状态：M1（机制闭环）+ M2（UI 发布面）已实现并全量测试通过。** 草线原列四模式(`scoring`/`round_robin`/`pooled`/`manual`)+ `talkativeness`。反向评审发现现有 in-band 机制(`@`、order_hint、panel)已覆盖「指定单人 / 全员 / 顺序 / 子集 / 派活」整个谱系,**只剩两个洞**:① per-guest 持久发言倾向 → **`talkativeness`**(主线);② 零成本「点名才说话」→ **`manual`** 房间档。`round_robin` / `pooled` 双双暂缓。落地承重契约已同步进 `CLAUDE.md`「发言权重与手动模式（P16）」段。
+>
+> **形态:机制 + UI 一起发布。** 调度旋钮是 toC 用户向特性,不能 toml-only 出厂(与现有 per-guest 设置面板不一致)。P16 分两个里程碑:**M1 机制闭环**(toml 驱动,开发/测试态) → **M2 发布面**(room 设置加 checkbox、guest 设置加滑杆)。两个旋钮都不改 cwd/client,**走 `swap_room_config` 轻热替**(下一轮 pick 当场生效、不 cancel in-flight、不重建茶客),区别于 permission/isolation/LLM 的 `_replace_session` 重建。
+
+## Summary —— 反向评审结论先行
+
+把 P16 提议的能力逐件对照现状,问「这个你是不是已经有了」:
+
+| 原 P16 提议 | 现有等价手段 | 真增量 | 裁决 |
+|---|---|---|---|
+| `round_robin`(全员轮转) | `@all` 全员一次 + handoff `panel`(子集+顺序+summarizer,本就串行轮转) | 仅「持久自动 + 起头轮换」,且**违背 §2「打分>固定轮询」自我矛盾**、token 重 | **暂缓** |
+| `pooled`(加权随机) | `scoring` 已占 relevance-aware niche | 非确定性,撞取证回放 | **暂缓** |
+| `manual`(只点名) | `want_threshold=1.0`(阈值上限就是 1.0)行为约等价 | **不是新行为,是省成本**:跳过每 pick 的 N 次打分 LLM 调用 | **留,定位「零成本 summon-only」** |
+| `talkativeness`(per-guest 权重) | 无:人设文本不可靠、`want_threshold` 整房级、task goal 临时且软 | **填了唯一真空洞**:per-guest、持久、确定、可调、不改人设 | **留,升为主线** |
+
+**一句话**:P16 = `talkativeness`(茶客级音量旋钮) + `manual`(房间级总开关 scoring↔manual)。**不引入新控制流轴**,每件都对得上一个现存手段覆盖不到的洞,贴合原则线「先做小闭环,宁可直接也不提前抽象成平台」。
+
+## 反向评审:与现有 `@`/task/handoff 调度的边界
+
+ChaHua 现在调度谁说话**全是 in-band(用消息/任务表达意图),没有任何 out-of-band 模式开关**:
+
+| 手段 | 机制 | 硬/软 | 粒度 |
+|---|---|---|---|
+| 指定单人 | `@mention` 确定性路由(score=1.0、跳打分、绕阈值) | 硬 | 单人 |
+| 全员一次 | `@broadcast`(`@all`/`@大家`)绕冷却+打分全员各一次 | 硬 | 全员 |
+| 软发言顺序 | task goal「X先 Y后 Z总结」→ `<order_hint>`,scorer 读完整 goal(`render_scoring_header`) | 软 | 顺序 |
+| 硬顺序/子集圆桌 | handoff `panel`:一个 turn 内 N(+1) 位串行 speak、后者看得见前者、可指定 summarizer | 硬 | 子集+顺序 |
+| 显式派活 | handoff `delegate` / `review` | 硬 | 单人 |
+| 管理者自循环 | MTS 托管会话 | 硬 | 自动 |
+| 自发接话 | `scoring`(默认) | 软 | 打分 |
+
+这套面已覆盖整个谱系。对它做差集,**只剩两个洞**:
+
+- **洞 1 —— per-guest 持久发言倾向**:想让某位茶客"主咖"或"高冷",现状只能① 写人设(LLM 时灵时不灵、要改人设)② 调 `want_threshold`(整房一起动)③ 写 task goal(任务级、临时、软)。没一个是 per-guest + 持久 + 确定。→ **`talkativeness` 填它**。
+- **洞 2 —— 零成本「点名才说话」**:`want_threshold=1.0` 行为几乎是"不点名不说",但仍每 pick 烧 N 次打分。贵模型房间想"待命且免费"。→ **`manual` 填它**(真增量是成本,不是行为)。
+
+**round_robin 为什么没进**:它的"全员各一次"被 `@all`+`panel` 吃掉;唯一增量"持久自动轮转"既 token 重、又恰是 §2 立论要超越的"固定轮询",自我矛盾。详见「暂缓事项」。
+
+## 设计一:`talkativeness`(主线)—— scoring 路径上的乘性偏置
+
+新增 `[[guest]].talkativeness: float`,默认 `1.0`,范围 `[0.0, 4.0]`(0=自发时哑、1=原样、>1=爱抢、4 是 sanity 上限防误填)。
+
+**唯一作用点**:`scoring` 档 auto-pick 拿到打分结果**之后**:
+
+```
+effective_score = clamp(base_score × talkativeness, 0.0, 1.0)
+```
+
+- `base_score` = `IntentScorer` 返回的原始 LLM 分(`scoring.py` 行为**一字不动**:严格 JSON + 解析失败降级 0 + 自身 clamp [0,1])。
+- `effective_score` 驱动:① 阈值比较(≥ `threshold` 才入选)② 倒序排名取前 k ③ envelope `data.scores`(所见即所排)。
+- **乘性而非加性**:`1.0` 严格 no-op;<1 线性 damp;>1 放大。有意取舍:`base_score=0`(话题完全无关)再高权重也是 0 —— 「爱说话」≠「乱插话」。
+
+**绝不作用的地方(承重)**:`@mention` / `@broadcast`(score=1.0 是路由信号不是意愿分,缩放会让被点名的高冷茶客掉阈值下,破坏「点名必应」)、`handoff` / `MTS`(显式编排,winner 不打分)、`cooldown` 门(eligibility 不是分数)、`scoring.py` 打分 prompt(talkativeness 是 orchestrator 层后处理,**不进 prompt**、不污染「茶客自己怎么想」)。
+
+**取证(加 dataclass 字段≠取证完成,必须显式穿透序列化)**:`ScoreResult` 加 `base_score: float = 0.0` 只是**载体**——现有两条序列化链都不自动带出去:`score_to_dict`(`task_rendering.py:183`)只发 `guest_name/score/kind`,`record_scoring` entry(`debug_recorder.py:308`)只写 `guest/score/kind/raw`,前端历史投影(`debug_panel.js:493`)也只取这些。所以取证分三段写清:
+- **实时 `turn_start.data.scores` 只保留 effective `score`**(不动 `score_to_dict`)—— 线上 envelope 不为 base_score 加宽。
+- **debug jsonl 可选加 `base_score` + `talkativeness`**:在 `record_scoring` entry dict 显式补两 key(`talk=1.0` 可省)。这是"看得到 raw×talk"的真正落点。
+- **前端 debug 面板可选展示**:`debug_panel.js:493` 投影补读才显示。
+
+加字段/加 key 都 additive,**不 bump `schema_version`**。
+
+**默认解析:`None`=未填→`1.0`,`0.0`=合法显式(哑茶客),禁 `or 1.0`**。config 层 talkativeness 解析成 `Optional[float]`(缺=`None`);use 点用 `talkativeness if talkativeness is not None else 1.0`,**绝不** `talkativeness or 1.0`(`0.0 or 1.0 == 1.0` 把哑茶客吞成默认 —— 与 permission/isolation 的 `禁 or DEFAULT_MODE` 同坑,`admin_guest.py:53`)。**MVP 无 manifest 联动**(理由见暂缓),coalesce 只两级:手写值 → `1.0`。
+
+## 设计二:`manual`(省钱开关)—— 房间档,零成本 summon-only
+
+新增 `[room].schedule_mode: str`,默认 `"scoring"`,MVP 白名单 `VALID_SCHEDULE_MODES = {"scoring", "manual"}`。
+
+`scoring`(默认)= 现状不变。`manual` = `pick_next_speaker` auto-pick 第 3 档**恒返 `[]`**:
+
+- 茶客**永不自发接话**;普通消息(无 `@`)→ 没人理,立即 `turn_end(next="user")`,**零打分 LLM 调用**。
+- `@mention` / `@broadcast` 照常路由(前两档模式无关):「`@宝总` → 宝总一句 → 停」「`@all` → 全员各一句 → 停」。
+- **handoff / MTS 照常**(走 `run_pending_handoff` drain loop,不经 auto-pick)。`manual` 房间 delegate / 圆桌 / 托管会话全可用。
+
+**定位准确性(评审重点)**:manual 行为约等于 `want_threshold=1.0`,但**真价值是省掉每条消息那 N 次打分** —— 把"待命且免费"做成显式开关,不让用户拿阈值近似还白烧 token。不当"新行为"卖。
+
+用例:贵模型房间不想自发烧 token;强控房间"我点谁谁说";纯 handoff / MTS 驱动的工作房间。
+
+## 行为示例(实际跑起来什么样)
+
+房间有 宝总(财务)、汪小姐(销售)、陶陶(运营),`want_threshold=0.45`。
+
+### scoring 默认 + talkativeness 调权
+
+```
+你: 这季度预算要砍 20%,哪块先动?
+
+【全员 talkativeness = 1.0(默认)】
+  宝总 原始 0.7 → 实际 0.7 ≥ 0.45 → 发言
+  陶陶 原始 0.3 → 实际 0.3 < 0.45 → 沉默   → 只有宝总接话
+
+【陶陶 = 1.8(话痨)】
+  陶陶 0.3 × 1.8 = 0.54 ≥ 0.45 → 也插进来  → 宝总 + 陶陶
+
+【宝总 = 0.5(高冷)】
+  宝总 0.7 × 0.5 = 0.35 < 0.45 → 相关话题都忍住 → 要原始分 0.9 才肯开口
+
+【宝总被 @,即便 = 0.5】
+  你: @宝总 你怎么看?
+  → mention 路由,score=1.0,talkativeness 不缩放 → 宝总必应
+```
+
+### manual 档
+
+```
+你: 今天预算又超了,头疼。
+  → (静默,没人理,等你。零打分调用)
+你: @宝总 你怎么看?
+宝总: 超在哪块?营销还是采购?先把大头摁住。   → (说完即停,其他人不自动跟)
+你: @all 都说一句。
+宝总: ……  汪小姐: ……  陶陶: ……          → (全员各一句,说完停)
+```
+
+**两轴心智模型**:`schedule_mode` 是房间总开关(scoring=自发开 / manual=自发关),`talkativeness` 是 scoring 开着时给每位茶客的音量旋钮。manual 下没有"自发",talkativeness 无东西可作用(空转无害)。
+
+## 生效路径:轻热替 vs 重建(承重)
+
+P16 两个旋钮都是**声明性配置字段,不改 cwd / LLM client / agent 实例**,所以走 **`swap_room_config` 轻热替**,不走 `_replace_session` 重建。`swap_room_config` 的 docstring 已经把这条边界写死:「只适合编排参数 / 用户配置之类的'声明性'字段更新;茶客增减 / persona 切换 / permission 改这些需要重建 `TeaGuest` 的,仍走 `_replace_session`」。
+
+| 改什么 | 路径 | 代价 | 生效时机 |
+|---|---|---|---|
+| permission / isolation / LLM | `_cancel_and_drain_all_foreground` + `_replace_session` | cancel+drain+重 spawn agentao | 重建后 |
+| want_threshold 等编排参数 | `swap_room_config`(`object.__setattr__` + `set_config`) | 一次 attribute swap | **下一轮 pick,不打断当前发言** |
+| **`schedule_mode`**(P16) | **`swap_room_config`** | 同上 + `dataclasses.replace(cfg, schedule_mode=...)` | **下一轮 pick** |
+| **`talkativeness`**(P16) | **`swap_room_config`** + 刷新 `_GuestEntry.talkativeness` | 同上 + 遍历新 RoomConfig 的 guest 推 per-guest 值 | **下一轮 pick** |
+
+- **`schedule_mode`**:走 `RoomConfig` 专用字段(**不混进数值 override**,见 M1),且 **schedule_mode 必须穿进 `_make_orchestrator_config`、不能在 callsite 无脑 `dataclasses.replace`**——后者会盖掉「显式 SDK 入参优先」契约(`_make_orchestrator_config` 在 `explicit is not None` 时直接 `return explicit`,`session.py:331`;`build_room_session` 正是传 `explicit=orchestrator_config`,`session.py:471`)。正确口径:`_make_orchestrator_config(overrides, *, schedule_mode="scoring", explicit=None)` —— `explicit` 给了就**完全优先**(它自带 schedule_mode,不被覆盖);只有无 explicit 的正常 server/CLI 路径才把 `RoomConfig.schedule_mode` 经 `dataclasses.replace` 写进 `OrchestratorConfig`。`swap_room_config` 没 explicit,照常用 `new_rc.schedule_mode`。纯 attribute swap,无重建。
+- **`talkativeness`**:per-guest,不在 `OrchestratorConfig` 里。`swap_room_config` 末尾补一步:遍历 `new_rc.guests`,把 `gc.talkativeness if ... is not None else 1.0` 推进 orchestrator 的 `_GuestEntry`(可变 `@dataclass`,原地改字段)。**只刷新当前 `_guests` 已存在的 name —— 缺失 / 新增茶客不在轻热替职责内**(茶客增删改 agent,走 `_replace_session`;这条边界防后人把 `swap_room_config` 误用到增删场景)。`_GuestEntry` 不重建 → 茶客的 agentao 实例 / 进程内对话窗口 / 记忆全不动 → 下一轮打分读新权重。
+
+**为什么不重建**:talkativeness 是调音旋钮,要"边拨边看",重建会 cancel 当前发言 + 丢 in-flight + 重 onboarding,对一个数值微调是过度代价、且毁掉"即时看效果"的用途。schedule_mode 同理。这正是 `swap_room_config` 存在的意义。
+
+## M1：机制闭环(toml 驱动,开发/测试态)
+
+配置四点闭环 —— 与 P6.3 `max_turns` 同款纪律(漏一点字段被静默吞):
+
+1. **`config.py` 定义 + 校验**
+   - `[room].schedule_mode`:string,默认 `"scoring"`。专用 enum 校验 `VALID_SCHEDULE_MODES = {"scoring","manual"}`(`round_robin`/`pooled` 不入白名单 → `RoomConfigError`,hint 区分「暂缓/未实现」与「拼错」)。加进 `_ALLOWED_ROOM_KEYS`(`config.py:84`)。**不进 `ORCH_FIELD_BOUNDS`**(数值表)+ **不走 `orchestrator_overrides`**(`_build_orchestrator_overrides`(`config.py:444`)只遍历 `ORCH_FIELD_BOUNDS`,字符串塞进去会"白名单允许但被静默忽略")。
+   - `[[guest]].talkativeness`:float,默认 `1.0`,范围 `[0.0,4.0]`。加进 `_ALLOWED_GUEST_KEYS`(`config.py:90`)+ `GuestConfig`(`config.py:155`)。bool 先剔;越界 `RoomConfigError`;`Optional[float]`、`None`=未显式选。
+2. **`session.py` 装配**
+   - **schedule_mode 走专用字段 + 穿进 `_make_orchestrator_config`**:`RoomConfig` 加 `schedule_mode: str = "scoring"`(`_build` 解析填);`OrchestratorConfig` 加 `schedule_mode: str = "scoring"`(`orchestrator_config.py:13`)。`_make_orchestrator_config(overrides, *, schedule_mode="scoring", explicit=None)`:`explicit` 给了**完全优先**(自带 schedule_mode,不覆盖,守住 SDK 入参契约,`session.py:331`);否则把 `schedule_mode` 经 `dataclasses.replace` 写进。**不在 callsite 无脑 replace**(会盖 explicit)。`swap_room_config` 无 explicit、传 `new_rc.schedule_mode`。
+   - **talkativeness 走 register 形参**:`Orchestrator.register(guest, persona_md, *, talkativeness=1.0)`(现签名只收前两个,`orchestrator.py:201`),存 `_GuestEntry.talkativeness`(`orchestrator.py:83` 加第三字段)。`session.py:509` 调用点传 `gc.talkativeness if ... is not None else 1.0`。`_pick_by_scoring` 从 `_GuestEntry` 读。(不另起并行 dict,与 `_GuestEntry` 同生命周期。)
+3. **选人 + 偏置**
+   - `pick_next_speaker`(`_orchestrator_scoring.py:55`)第 3 档按 `config.schedule_mode` 分派:`scoring` → 现有逻辑、`manual` → `[]`;前两档(`@`)不动。
+   - scoring 子分支(`_orchestrator_scoring.py:142-185`):gather 后 `effective = clamp(base × talk)`(talk 从 `_GuestEntry` 读),threshold/排名/envelope 用 effective,`base_score` 入 `ScoreResult`。
+4. **回写保真 + 本不变量**:`_render_room_toml`(`admin_toml.py:180`)非默认才写 + `_render_guest` 白名单(`admin_toml.py:67`)加 `talkativeness`;`docs/INVARIANTS.md` 同步(见末节)。
+
+M1 验收:手改 `room.toml` + 切房/重启重建 → `manual` 不自发、talkativeness 改排名。**M1 不带 UI,但也不是发布形态**(见 M2)。
+
+## M2：发布面(UI 控件,release-blocking)
+
+hand-edit toml 只是 M1 开发态驱动。打包后 `room.toml` 住 `~/Library/Application Support/chahua/`,让 toC 用户翻 Library 改文件不可接受,且与现有 per-guest 设置面板(permission/isolation/LLM/MCP 全有 UI)不一致。**两个旋钮发布前必须有 UI**。基建全现成 —— `room_settings.js` / `guest_settings.js` 已是 diff-提交弹窗,`swap_room_config` 已是轻热替路径,边际很小。
+
+### schedule_mode —— room 设置里一个 checkbox
+
+二值(scoring/manual)→ checkbox 是天然控件(「☑ 手动模式:茶客只在被点名时发言」)。挂进 `room_settings.js` 现有弹窗:
+
+| 触点 | 改动 |
+|---|---|
+| `app/renderer/index.html` + `room_settings.js` | 加 checkbox + diff 项(改了才发帧),`fillForm` 从 `snapshot.schedule_mode` 设初值 |
+| `server_room_snapshot.py:192` 区域(room snapshot) | room 顶层加 `schedule_mode` 字段(否则 checkbox 读不到当前态) |
+| inbound `update_room_schedule_mode` + `_INBOUND_ROUTES`(`server.py`) | 新帧;`require_str` + 白名单校验。(或扩 `update_room_orchestrator` 捎带,但那会污染"overrides=纯数值"语义,不推荐) |
+| `server_inbound_admin.py` handler | `_update_room_schedule_mode`:`admin` 写 toml 返回 new RoomConfig → `swap_room_config(new_rc)` → `_emit_room_snapshot`。**不 cancel inflight、不 `_replace_session`**(照 `_update_room_orchestrator` 口径) |
+| `admin_room.py` mutator | `update_room_schedule_mode` 写 `[room].schedule_mode`(默认不写) |
+
+### talkativeness —— guest 设置里一个滑杆
+
+per-guest + 连续值 → 0–4 滑杆(显示数值),挂进 `guest_settings.js` 现有弹窗:
+
+| 触点 | 改动 |
+|---|---|
+| `app/renderer/index.html` + `guest_settings.js` | 加滑杆 + `diffPayloads` 分支(改了才发 `UPDATE_GUEST_TALKATIVENESS`),`fillForm` 从 `g.talkativeness` 设初值 |
+| `server_room_snapshot.py:192` 茶客快照 | guest dict 加 `"talkativeness": gc.talkativeness`(默认 1.0 也带,前端要回显) |
+| inbound `update_guest_talkativeness` + 路由 | 新帧;校验 float + 范围 |
+| `server_inbound_admin.py` handler | `_update_guest_talkativeness`:`admin` 写 toml 返回 new RoomConfig → `swap_room_config(new_rc)`(轻热替 + 刷新 `_GuestEntry.talkativeness`)→ snapshot。**talkativeness 是首个走轻热替的 guest 设置**(permission/isolation 改 agent 必重建,它不改 → 不重建) |
+| `admin_guest.py:165` 同款 | `update_guest_talkativeness` mutator(默认 1.0 不写) |
+
+UX 增强(非承重):`schedule_mode=manual` 时 talkativeness 滑杆置灰(manual 下无 auto-pick,权重空转)。
+
+## 承重不变量(提案,落地时同步进 CLAUDE.md / INVARIANTS)
+
+- **`schedule_mode` 只换 auto-pick 第 3 档;`@mention` / `@broadcast` 在所有档下字面不变**。前两档是用户显式召唤,档无关、不打分、不吃 talkativeness。**Why**:`@` 是确定性路由契约,破了「点名必应」就破。
+- **调度档与 handoff / MTS 正交**。delegate/review/panel/MTS 跑在 `run_pending_handoff` drain loop,**不经** auto-pick,故 `manual` 下照常工作。延续「`_run_ai_chain` 与 `run_pending_handoff` 严格分流」。
+- **`manual` auto-pick 恒空、零 LLM 打分**。只有 `@`/broadcast/handoff/MTS 能让茶客说话。**真增量是成本不是行为**(≈ `want_threshold=1.0` 但跳过 N 次打分)。
+- **`talkativeness` 仅作用于 `scoring` 档 auto-pick 的分数:`effective = clamp(base × talkativeness, 0, 1)`**。驱动阈值 + 排名 + envelope `data.scores`(所见即所排)。**绝不**作用于 `@`/broadcast/handoff/MTS/cooldown 门,**绝不**进打分 prompt。`scoring.py` 自身行为一字不动。
+- **取证靠显式穿透序列化,不靠加 dataclass 字段自动完成**。`ScoreResult.base_score` 只是载体;实时 `data.scores`(`task_rendering.py:183`)只发 effective;要看 raw×talk 必须在 `record_scoring` entry(`debug_recorder.py:308`)补 key + 前端投影(`debug_panel.js:493`)补读。三处不改=没取证。
+- **talkativeness 默认 coalesce:`None`→`1.0`,`0.0`=合法哑茶客,禁 `or 1.0`**。use 点 `... if x is not None else 1.0`(`admin_guest.py:53` 同坑)。MVP 无 manifest,coalesce 两级。
+- **P16 两旋钮走 `swap_room_config` 轻热替,不走 `_replace_session`**。声明性字段、不改 cwd/client/agent → 下一轮 pick 当场生效、不 cancel in-flight、不重建茶客。talkativeness 额外要 `swap_room_config` 刷新 `_GuestEntry.talkativeness`,**只刷当前 `_guests` 已存在 name**(茶客增删走 `_replace_session`,不在轻热替职责内)。**Why**:调音旋钮要"边拨边看",重建是过度代价且毁掉即时性;这正是 `swap_room_config` docstring 划定的边界。
+- **schedule_mode 经 `_make_orchestrator_config(..., schedule_mode=, explicit=)` 装配,`explicit` 完全优先**。显式 SDK 入参(`explicit is not None`)自带 schedule_mode、直接 `return`,**不被** `RoomConfig.schedule_mode` 覆盖(守 `session.py:331` 既有「显式入参优先」契约);只有无 explicit 的 server/CLI 路径才写入。**禁**在 callsite 无脑 `dataclasses.replace`(会盖 explicit)。
+- **`schedule_mode` 白名单严格**。未知值(含暂缓的 `round_robin`/`pooled`)→ `RoomConfigError`,hint 区分「暂缓/未实现」与「拼错」。
+- **debug `scoring_path` 增 `manual` 值**(`debug_recorder.py:59`);manual 多为空 turn 但仍各记一行(「每 pick 周期一行 turns.jsonl」)。新增 path 值不 bump `schema_version`。
+- **UI 控件下发态来自 room snapshot,不新增专用 ack**。`schedule_mode`(room 顶层)/ `talkativeness`(guest dict)加进 `emit_room_info` 快照;`swap_room_config` 后 `_emit_room_snapshot` 整批回显。不 bump `schema_version`。
+
+## P16 改造触点(提案)
+
+### M1 机制
+
+| 层 | 文件:位置 | 改动 |
+|---|---|---|
+| 配置定义 | `config.py:84` `_ALLOWED_ROOM_KEYS` / `:90` `_ALLOWED_GUEST_KEYS` | 加 `schedule_mode`(room)/ `talkativeness`(guest);`VALID_SCHEDULE_MODES` enum + talkativeness 范围校验(bool 剔、越界 raise、透 None) |
+| 配置数据类 | `config.py:155` `GuestConfig` / `:225` `RoomConfig` / `orchestrator_config.py:13` | `GuestConfig.talkativeness: Optional[float]`;**`RoomConfig.schedule_mode: str = "scoring"`**(专用字段);`OrchestratorConfig.schedule_mode: str = "scoring"` |
+| 装配 schedule_mode | `session.py:323` `_make_orchestrator_config` + `:281` `swap_room_config` | schedule_mode 穿进 `_make_orchestrator_config(..., schedule_mode=, explicit=)`,**`explicit` 完全优先**(守 SDK 契约);swap 无 explicit 传 `new_rc.schedule_mode`。**不经** `orchestrator_overrides`、**不在 callsite 无脑 replace** |
+| 装配 talkativeness | `orchestrator.py:201` `register` / `:83` `_GuestEntry` / `session.py:509` 调用点 | `register(guest, persona_md, *, talkativeness=1.0)`;`_GuestEntry` 加字段;调用点 `is not None` coalesce |
+| 选人分派 | `_orchestrator_scoring.py:55` `pick_next_speaker` | 第 3 档按 `schedule_mode` 分派 scoring/manual;前两档不动 |
+| scoring 偏置 | `_orchestrator_scoring.py:142-185` | `effective = clamp(base × talk)`(talk 从 `_GuestEntry`);threshold/排名/envelope 用 effective;`base_score` 入 `ScoreResult` |
+| 结果类型 | `scoring.py:53` `ScoreResult` | 加 `base_score: float = 0.0` —— **仅载体,不自动序列化** |
+| 取证(显式穿透) | `debug_recorder.py:59` `SCORING_PATH_*` / `:308` entry / `debug_panel.js:493` | 加 `SCORING_PATH_MANUAL`;entry dict 补 `base_score`/`talkativeness`;前端投影补读。`data.scores` 不改 |
+| 回写 toml | `admin_toml.py:67` 白名单 / `:180` `_render_room_toml` | `[room].schedule_mode` / `[[guest]].talkativeness` 非默认才写 |
+
+### M2 UI(发布前置)
+
+| 层 | 文件:位置 | 改动 |
+|---|---|---|
+| room snapshot | `server_room_snapshot.py:192` 区域 | room 顶层加 `schedule_mode`;guest dict 加 `talkativeness` |
+| inbound 帧 | `server_inbound_admin.py` + `server.py` `_INBOUND_ROUTES` | `update_room_schedule_mode` / `update_guest_talkativeness` + 路由 |
+| handler(轻热替) | `server_inbound_admin.py` | 两个 handler:admin 写 toml 返回 new RoomConfig → `swap_room_config(new_rc)` → snapshot。**不 `_replace_session`、不 cancel inflight**(talkativeness handler 额外靠 `swap_room_config` 刷新 `_GuestEntry`) |
+| swap 刷新 talkativeness | `session.py:281` `swap_room_config` | 末尾遍历 `new_rc.guests` 推 `_GuestEntry.talkativeness`(原地改可变 dataclass);**只刷 `_guests` 已存在 name,增删不在职责内** |
+| mutator | `admin_room.py` / `admin_guest.py:165` | `update_room_schedule_mode` / `update_guest_talkativeness`(默认不写) |
+| 前端控件 | `index.html` + `room_settings.js` / `guest_settings.js` | room checkbox / guest 0–4 滑杆;`fillForm` 回显;diff 提交;manual 时滑杆置灰(非承重) |
+
+**对比 round_robin 砍掉后省下的复杂度**:不需要 `_rr_cursor` / `_burst_spoken` 轮转状态机、`let_speak` 钩子、burst 清空、`SCORING_PATH_ROUND_ROBIN`。manual 只是 auto-pick 多一个 `return []`。
+
+## MVP 范围(M1 + M2 一起发布)
+
+机制 + UI 都进 MVP,全复用既有路径:
+
+1. **`talkativeness`**(主线):toml 解析 + scoring 乘性偏置 + reclamp + guest 滑杆 UI。
+2. **`manual`**:`schedule_mode ∈ {scoring, manual}` + auto-pick 恒空 + room checkbox UI。
+3. **轻热替生效**:复用 `swap_room_config`(schedule_mode + per-guest talkativeness 刷新),不 `_replace_session`。
+4. **回写保真 + room snapshot 字段 + debug 基础字段**。
+
+### 暂缓事项(列定义 + 砍它的理由)
+
+- **`round_robin`(全员轮转)**:核心"全员各一次"被 `@all` + `panel` 吃掉;唯一增量"持久自动+起头轮换"既 token 重、又恰是 §2 要超越的"固定轮询",自我矛盾。真要"ambient 全员",最小动作是给 broadcast 一个 default 值(`schedule_mode` 加 `broadcast`),**不是**发明轮转状态机。
+- **`pooled`(加权随机)**:非确定性撞取证回放;默认 `talkativeness=1.0` 退化成无序轮询;niche 已被 `scoring` 占。批量单 call 变体退回"中央调度员",违背 §2。
+- **persona manifest `[defaults.guest].talkativeness` 联动**:manifest 是**硬编码白名单**(`_ALLOWED_DEFAULTS_GUEST_KEYS = {permission, isolation}`,`persona_manifest.py:39`)+ 显式 dataclass 字段(`persona_manifest.py:55`),**不**从 `_ALLOWED_GUEST_KEYS` 派生 —— 加 guest key 不"白送"。真要做须 4 触点:① 白名单加 key ② `PersonaManifest` 加 `defaults_guest_talkativeness` + 校验 ③ `_build_guest_with_manifest_defaults` coalesce ④ 回归。等"话痨人设要可分发"再加。
+- **per-guest 模式**:档只房间级,不做"这茶客轮转那茶客打分"。
+- **策略插件 / 图编排 DSL / 中央调度员 LLM call / talkativeness 进 prompt / 动态自调**:原则线,不碰。
+
+## 测试计划(复现优先:先写失败用例)
+
+- **配置校验**:未知 `schedule_mode`(含 `round_robin`/`pooled`)→ `RoomConfigError`「暂缓/拼错」分诊;`talkativeness` 非数值/bool/越界 [0,4] → `RoomConfigError`;缺省 → mode=`scoring` / talk 透 `None`。
+- **talkativeness 偏置**:① `effective = clamp(base × talk)`,`talk=0.5` 把 0.8 压到 0.4 < 0.45 落选;`talk=1.8` 把 0.3 抬到 0.54 入选;② `talk=1.0` 严格 no-op;③ reclamp(`0.8×2=1.6→1.0`);④ `base=0 × 任意 = 0`;⑤ **不作用于 `@`/broadcast**(被 `@` 的 `talk=0.5` 茶客仍 score=1.0 入选);⑥ 不作用于 handoff/MTS。
+- **`0.0` 不被吞**:显式 `talkativeness=0.0` use 点得 `0.0`(钉死 `is not None`);缺字段→`1.0`。
+- **manual**:① auto-pick 恒空、`IntentScorer.score` **零调用**(mock 断言 0 次);② `@宝总` 仍路由一句即停;③ `@all` 仍全员一次;④ delegate / MTS 在 manual 房照常跑通。
+- **schedule_mode 串接(钉点 1)**:断言经 `RoomConfig.schedule_mode` 专用字段到 `OrchestratorConfig`、`manual` 真生效;**反向断言不在 `orchestrator_overrides` 里**(防回归到"白名单允许但被忽略")。
+- **explicit 入参优先(钉点)**:`_make_orchestrator_config(overrides, schedule_mode="manual", explicit=cfg_with_scoring)` 返回的 `schedule_mode` 仍是 `explicit` 的值(`scoring`),**不被** `schedule_mode=` 参覆盖(守 SDK 入参契约)。
+- **轻热替生效(钉点)**:`update_room_schedule_mode` / `update_guest_talkativeness` → `swap_room_config` 后下一轮 pick 用新值、**不触发 `_replace_session`、不 cancel in-flight**(断言茶客 agentao 实例 id 不变、in-flight turn 未被打断);talkativeness 改后 `_GuestEntry.talkativeness` 被刷新。
+- **取证显式穿透**:`scoring_path=manual` 落 turns.jsonl;实时 `data.scores` 是 effective(不含 base_score);**断言 `record_scoring` 落盘 entry 含 `base_score`/`talkativeness`**(改了 entry 才有,反钉"加字段≠取证")。
+- **round-trip toml**:写 `schedule_mode`/`talkativeness` → reload 保住;默认值(scoring/1.0)**不写盘**;`_render_guest` 白名单含 talkativeness。
+- **UI 下发**:`swap_room_config` 后重发 room snapshot,断言 `schedule_mode`(room 顶层)/ `talkativeness`(guest dict)为新值;**不新增专用 ack 帧**。
+- **正交回归**:handoff drain / MTS 待机 / bg run 在 `manual` 下全绿(跑既有 P7/P8.3/P8.4/P11 集)。
+
+## CLAUDE.md / INVARIANTS 同步清单(落地后补)
+
+- CLAUDE.md「关键不变量」加「§P16 发言权重与手动模式」:档只换 auto-pick 第 3 档、`@` 路由档无关、档与 handoff/MTS 正交、manual 恒空(增量是成本)、talkativeness 仅 scoring 乘性偏置 + reclamp + 不进 prompt + `is not None` coalesce、**两旋钮走 `swap_room_config` 轻热替不走 `_replace_session`**、取证须显式穿透、`schedule_mode` 白名单严格、`scoring_path` 增值不 bump schema。
+- CLAUDE.md「Python 后端模块分工」`_orchestrator_scoring.py`:补「P16 起第 3 档按 `schedule_mode` 分派 scoring/manual,scoring 路加 talkativeness 偏置」;`session.py` 补「`swap_room_config` 兼刷 per-guest talkativeness」。
+- CLAUDE.md「配置与 LLM 装配」/「测试」:补 `schedule_mode` 走 `RoomConfig` 专用字段(不混 `orchestrator_overrides`)+ talkativeness `is not None` coalesce 坑 + 两旋钮轻热替路径。
+- `docs/INVARIANTS.md`:加 §P16 完整 rationale(反向评审为何砍 round_robin/pooled、为何不做 manifest 联动 [硬编码白名单非派生]、乘性 vs 加性取舍、manual 定位为成本、取证显式穿透、轻热替 vs 重建边界、档正交 handoff)。
+- `docs/研究-同类项目与演进方向.md` §四.2:指向 `docs/P16-发言权重与手动模式.md`。

--- a/docs/研究-同类项目与演进方向.md
+++ b/docs/研究-同类项目与演进方向.md
@@ -1,0 +1,188 @@
+# 研究：同类项目与 ChaHua 演进方向
+
+> 调研日期：2026-06-19  
+> 口径：数据与项目状态是 2026-06 的快照；star、功能数量、beta/GA 状态均可能变化，正式决策前需回源核验。
+
+---
+
+## 一、核心结论
+
+ChaHua 的稀缺点不是“AI 群聊”本身，而是这套组合：**多茶客自然接话 + 能用工具干活 + 任务房间 + artifact 归集 + 取证回放 + 本地优先安全边界**。
+
+竞品大致分三类：
+
+- 桌面 AI 客户端：多数是单助手、工具客户端或多模型并排对比，不是真协作群聊。
+- 多 Agent 框架：能力强，但主要是库 / SDK，不是面向用户的桌面群聊产品。
+- 角色群聊产品：群聊和人设成熟，但多偏娱乐，通常缺任务、工具、写文件、取证和 artifact 工作流。
+
+所以演进方向应保持克制：**补齐标配能力，但不要把 ChaHua 改成通用 Agent 框架或纯角色扮演产品**。
+
+---
+
+## 二、代表项目速览
+
+| 类别 | 代表项目 | 对 ChaHua 的启发 |
+|---|---|---|
+| 桌面 / 本地 AI 客户端 | LobeChat、Cherry Studio、Chatbox、Jan、AnythingLLM、Open WebUI、5ire、Witsy、Super Agent Party | RAG、联网搜索、本地模型、MCP 工具市场、成本统计已是用户预期 |
+| 多 Agent 框架 | AutoGen / AG2、CrewAI、LangGraph、OpenAI Agents SDK、AgentScope、Google ADK | 调度策略、handoff、HITL、checkpoint、可观测性值得借鉴 |
+| 角色群聊 / Agent 社会 | SillyTavern、Character.AI、Generative Agents、AI-Town | talkativeness、多种发言顺序、角色生态、lorebook、长期记忆值得借鉴 |
+
+两个直接判断：
+
+- **Super Agent Party 已是桌面 AI 群聊同类**，所以不要再说“没有第二家”。ChaHua 的优势应表述为“工作容器和取证纵深更强”。
+- **SillyTavern 的调度体验成熟**，但它的核心不是“能干活的任务房间”。ChaHua 可以借调度 UX，不应转向纯娱乐角色扮演。
+
+---
+
+## 三、ChaHua 应守住的优势
+
+- **意愿打分接话**：比固定轮询更自然，比中央调度员更有群聊感。
+- **任务房间**：任务、决策、artifact、active task 让房间不只是聊天容器。
+- **artifact 工作流**：茶客写 `./task/<name>`，系统自动归集并回填来源。
+- **取证回放**：候选、分数、prompt、工具、产物按 turn 落盘，便于调试和复盘。
+- **最小权限与 HITL**：茶客多 propose，用户采纳；MCP 信任门、路径围栏、凭证不落盘。
+- **本地优先桌面形态**：Electron + Python sidecar，适合做隐私和本地模型体验。
+
+这些是主线，不应为了追竞品功能而破坏。
+
+---
+
+## 四、优先路线
+
+### 1. 联网搜索：先做，低风险
+
+agentao 已有 `web_search` / `web_fetch` 能力，ChaHua 重点不是重新造搜索，而是接通与配置。
+
+技术路线：
+
+- 依赖层启用 web 相关 extra 或补齐缺的依赖。
+- 在 UI / 配置里给出明确开关。
+- 默认策略保持保守：用户知道搜索会出网。
+- 先支持免 key 后端；需要 key 的后端后续再做。
+- 暂不接一堆搜索 MCP，不做复杂缓存，不把搜索结果塞进打分阶段。
+
+### 2. 调度体验：小步增强
+
+ChaHua 的默认仍是意愿打分，但应补几个简单旋钮，方便不同场景。**已细化并经反向评审收缩为 P16，详见 `docs/P16-发言权重与手动模式.md`。**
+
+反向评审(对照现有 `@mention` / task goal order_hint / handoff panel 调度面)后，原草线四模式里只有两个洞没被现状堵上，P16 因此瘦成两件：
+
+- **`[[guest]].talkativeness = 1.0` 默认**（主线）：唯一填了「per-guest 持久发言倾向」真空洞的旋钮。只影响 `scoring` path（乘性偏置 `clamp(base × talk, 0, 1)`），不影响 `@mention`、broadcast、handoff、MTS。
+- **`[room].schedule_mode ∈ {scoring, manual}`**：`manual` 是零成本的「点名才说话」开关（行为≈`want_threshold=1.0`，真增量是省掉每 pick 的 N 次打分）。
+- **暂缓**：`round_robin`（冗余于 `@all`+`panel`，且自我矛盾于「打分>固定轮询」）、`pooled`（非确定性撞取证回放）。
+- 核心隔离：档只换 auto-pick 这一档；handoff / MTS / `@` 确定性路由全部正交不动。不引入策略插件、图编排 DSL、中央调度员 LLM call。
+
+### 3. 房间级 RAG：先做最小可用，不做大平台
+
+RAG 是最大横向短板，但完整 RAG 很容易膨胀。ChaHua 应先解决一个具体问题：**房间资料多了以后，茶客能查到用户明确放进知识库的资料**。
+
+MVP 技术路线：
+
+- 新增 `rooms/<id>/knowledge/`，只索引用户明确放入的文件。
+- 新增 `knowledge_search` read-only 工具。
+- 先支持文本 / Markdown。
+- 先用一种 embedding 配置，优先复用现有 LLM 配置风格。
+- 索引坏了可重建，不阻断房间启动。
+
+后续增强：
+
+- citation 回到文件路径或 originating message。
+- 可选索引任务产物。
+- 本地 embedding。
+- turn 级检索缓存。
+- 暂不默认索引 `share/`、全部 transcript，不注入 scoring，不做多向量库 / 多后端 / 复杂 ANN，不和 lorebook 强行合并。
+
+### 4. 本地 LLM：补体验，不是重做运行时
+
+代码层已经支持 Ollama / OpenAI-compatible endpoint。下一步应补产品体验。
+
+技术路线：
+
+- UI 里提供本地模型入口。
+- 检测 Ollama 是否运行。
+- 拉取 / 展示本地模型列表。
+- 给出清晰错误：未启动、模型不存在、端点不可达。
+- 暂不内置大模型，不做复杂模型管理器，不把本地 LLM 与云登录态混成不可解释的一套状态。
+
+### 5. 长期记忆：先接通已有能力
+
+agentao 已有记忆能力，ChaHua 当前重点是把“房间 / 茶客 / 用户”作用域接清楚。
+
+技术路线：
+
+- 明确三种作用域：房间记忆、茶客跨房记忆、用户偏好记忆。
+- 先接通用户级跨房记忆。
+- 保持可关闭、可清理、可解释。
+
+后续增强：
+
+- importance 权重。
+- 后台抽取用户偏好。
+- 周期性 reflection。
+- 暂不上知识图谱，不做不可见、不可控的自动记忆。
+
+### 6. 取证、评估、成本：增强已有优势
+
+P6 已经是优势，应往“可验证开发”和“成本透明”走。
+
+技术路线：
+
+- debug 记录补采样参数、token 用量、模型信息。
+- 增加多茶客成本统计。
+- 将 turn 记录导出为 eval 数据。
+- 后续再对齐 OTel `gen_ai.*`。
+- 暂不接重型观测平台，不为了 OTel 重写 debug_recorder。
+
+---
+
+## 五、暂缓事项
+
+- **A2A / 外部 Agent 互联**：当前茶客同进程共享 transcript，进程内 handoff 已够用。只有要调用远程第三方 agent 时再做。
+- **复杂图编排 / DSL**：ChaHua 的核心是群聊房间，不是 LangGraph 替代品。
+- **独立 Guardrail 模型层**：可作为纵深防御，但不是当前主线。
+- **完整 persona 市场**：先把导入、更新、单文件导出和发现入口打磨好，再考虑中心化市场。
+- **文生图工作流**：可通过 MCP / ComfyUI 试点，不进近期主线。
+
+---
+
+## 六、推荐路线图
+
+近期：
+
+1. 启用联网搜索。
+2. 增加调度模式与 `talkativeness`。
+3. 做 RAG MVP：`knowledge/` + `knowledge_search` + 文本索引。
+
+中期：
+
+1. 本地 LLM UX：模型发现、端点检测、错误提示。
+2. 跨房长期记忆：先接用户级 memory store。
+3. 成本统计与 debug 数据导出。
+
+后续：
+
+1. RAG citation、本地 embedding、任务产物可选索引。
+2. persona 生态：角色卡兼容、单文件导出、发现页。
+3. OTel / eval / 从历史 turn 重跑。
+
+---
+
+## 七、执行原则
+
+- 优先复用 agentao 已有能力。
+- 每个功能先做一个小闭环，再扩展。
+- 默认保守：出网、记忆、索引都要可见、可关、可解释。
+- 不为“竞品有”而做；只做能强化“能干活的桌面群聊房间”的能力。
+- 技术路线宁可直接，也不要提前抽象成平台。
+
+---
+
+## 附录：来源提示
+
+本文保留的是方向性结论，不逐条绑定来源。若要把某个竞品断言写入发布材料或路线图承诺，需要重新核验对应项目 README / 官方文档 / issue 状态，尤其是：
+
+- star 数与活跃状态；
+- beta / GA 状态；
+- “是否支持多 agent 群聊”；
+- RAG、联网搜索、MCP、本地模型等功能细节；
+- “唯一”“无同款”“维护模式”等强判断。

--- a/tests/test_p16_m2_inbound.py
+++ b/tests/test_p16_m2_inbound.py
@@ -1,0 +1,188 @@
+"""P16 M2：room_info 快照字段 + swap_room_config 轻热替（schedule_mode / talkativeness）。
+
+承重点：
+
+- room_info 出 ``schedule_mode``（room 顶层）+ ``talkativeness``（guest dict，默认 1.0
+  也带，前端滑杆要回显）。
+- ``swap_room_config`` 轻热替：schedule_mode → ``orchestrator.config``；talkativeness →
+  ``_GuestEntry``，**不重建茶客**（orchestrator / TeaGuest 实例不变、不 _replace_session）。
+- mutator 写盘 + 范围 / 白名单校验 + 默认值不写盘。
+
+wire 层 dispatch / 类型校验在 ``test_server_inbound.py``（spy 路由测）。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chahua import admin
+from chahua.config import RoomConfigError, load_room_config
+from chahua.orchestrator_config import SCHEDULE_MODE_MANUAL, SCHEDULE_MODE_SCORING
+from chahua.server import ChahuaServer
+from chahua.session import build_room_session
+
+
+def _seed(env_paths, *, room_id="m2"):
+    return admin.create_room(
+        paths=env_paths, room_id=room_id, name=room_id,
+        guests=[{"persona": "chahua/personas/宝总/宝总.md", "name": "宝总"}],
+    )
+
+
+def _room_info_data(env_paths, session) -> dict:
+    srv = object.__new__(ChahuaServer)
+    srv._session = session  # type: ignore[attr-defined]
+    srv._paths = env_paths  # type: ignore[attr-defined]
+    captured: list[dict] = []
+    srv._emit_room_info(lambda env: captured.append(env.to_dict()))
+    assert len(captured) == 1
+    return captured[0]["data"]
+
+
+# ── room_info 快照字段 ────────────────────────────────────────────────────────
+
+
+def test_room_info_schedule_mode_and_talkativeness_defaults(env_paths):
+    rc = _seed(env_paths)
+    session = build_room_session(rc.room_dir, env_paths)
+    try:
+        data = _room_info_data(env_paths, session)
+        assert data["schedule_mode"] == SCHEDULE_MODE_SCORING
+        assert data["guests"][0]["talkativeness"] == 1.0
+    finally:
+        session.close()
+
+
+def test_room_info_reflects_non_default(env_paths):
+    rc = _seed(env_paths)
+    admin.update_room_schedule_mode(
+        paths=env_paths, room_dir=rc.room_dir, mode=SCHEDULE_MODE_MANUAL
+    )
+    admin.update_guest_talkativeness(
+        paths=env_paths, room_dir=rc.room_dir, name="宝总", talkativeness=1.8
+    )
+    session = build_room_session(rc.room_dir, env_paths)
+    try:
+        data = _room_info_data(env_paths, session)
+        assert data["schedule_mode"] == SCHEDULE_MODE_MANUAL
+        assert data["guests"][0]["talkativeness"] == 1.8
+    finally:
+        session.close()
+
+
+# ── swap_room_config 轻热替（不重建）─────────────────────────────────────────
+
+
+def test_swap_schedule_mode_light_no_rebuild(env_paths):
+    rc = _seed(env_paths)
+    session = build_room_session(rc.room_dir, env_paths)
+    try:
+        orch_before = session.orchestrator
+        new_rc = admin.update_room_schedule_mode(
+            paths=env_paths, room_dir=rc.room_dir, mode=SCHEDULE_MODE_MANUAL
+        )
+        session.swap_room_config(new_rc)
+        # 同 orchestrator 实例 —— 没 _replace_session 重建。
+        assert session.orchestrator is orch_before
+        assert session.orchestrator.config.schedule_mode == SCHEDULE_MODE_MANUAL
+        # 写盘保真。
+        assert load_room_config(
+            rc.room_dir, paths=env_paths
+        ).schedule_mode == SCHEDULE_MODE_MANUAL
+    finally:
+        session.close()
+
+
+def test_swap_talkativeness_light_no_rebuild(env_paths):
+    rc = _seed(env_paths)
+    session = build_room_session(rc.room_dir, env_paths)
+    try:
+        guest_before = session.orchestrator.get_guest("宝总")
+        new_rc = admin.update_guest_talkativeness(
+            paths=env_paths, room_dir=rc.room_dir, name="宝总", talkativeness=1.8
+        )
+        session.swap_room_config(new_rc)
+        # 同 TeaGuest 实例 —— agentao / 进程内会话 / 记忆全不动。
+        assert session.orchestrator.get_guest("宝总") is guest_before
+        assert session.orchestrator._guests["宝总"].talkativeness == 1.8
+        assert load_room_config(
+            rc.room_dir, paths=env_paths
+        ).guests[0].talkativeness == 1.8
+    finally:
+        session.close()
+
+
+def test_swap_talkativeness_explicit_zero(env_paths):
+    """显式 0.0（哑茶客）经 swap 落到 _GuestEntry，不被吞成 1.0。"""
+    rc = _seed(env_paths)
+    session = build_room_session(rc.room_dir, env_paths)
+    try:
+        new_rc = admin.update_guest_talkativeness(
+            paths=env_paths, room_dir=rc.room_dir, name="宝总", talkativeness=0.0
+        )
+        session.swap_room_config(new_rc)
+        assert session.orchestrator._guests["宝总"].talkativeness == 0.0
+    finally:
+        session.close()
+
+
+# ── mutator 校验 + 默认不写盘 ─────────────────────────────────────────────────
+
+
+def test_update_room_schedule_mode_rejects_deferred(env_paths):
+    rc = _seed(env_paths)
+    with pytest.raises(RoomConfigError):
+        admin.update_room_schedule_mode(
+            paths=env_paths, room_dir=rc.room_dir, mode="round_robin"
+        )
+
+
+def test_update_room_schedule_mode_default_not_written(env_paths):
+    rc = _seed(env_paths)
+    admin.update_room_schedule_mode(
+        paths=env_paths, room_dir=rc.room_dir, mode=SCHEDULE_MODE_MANUAL
+    )
+    admin.update_room_schedule_mode(
+        paths=env_paths, room_dir=rc.room_dir, mode=SCHEDULE_MODE_SCORING
+    )
+    toml = (rc.room_dir / "room.toml").read_text(encoding="utf-8")
+    assert "schedule_mode" not in toml
+
+
+@pytest.mark.parametrize("bad", [5.0, -0.5])
+def test_update_guest_talkativeness_out_of_range(env_paths, bad):
+    rc = _seed(env_paths)
+    with pytest.raises(RoomConfigError):
+        admin.update_guest_talkativeness(
+            paths=env_paths, room_dir=rc.room_dir, name="宝总", talkativeness=bad
+        )
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_update_guest_talkativeness_non_finite(env_paths, bad):
+    """mutator 写盘前拒非有限值（NaN 漏过区间判会落 'nan' 到 toml + 永久静默茶客）。"""
+    rc = _seed(env_paths)
+    with pytest.raises(RoomConfigError):
+        admin.update_guest_talkativeness(
+            paths=env_paths, room_dir=rc.room_dir, name="宝总", talkativeness=bad
+        )
+
+
+def test_update_guest_talkativeness_unknown_name(env_paths):
+    rc = _seed(env_paths)
+    with pytest.raises(ValueError):
+        admin.update_guest_talkativeness(
+            paths=env_paths, room_dir=rc.room_dir, name="查无此人", talkativeness=1.5
+        )
+
+
+def test_update_guest_talkativeness_default_not_written(env_paths):
+    rc = _seed(env_paths)
+    admin.update_guest_talkativeness(
+        paths=env_paths, room_dir=rc.room_dir, name="宝总", talkativeness=1.8
+    )
+    admin.update_guest_talkativeness(
+        paths=env_paths, room_dir=rc.room_dir, name="宝总", talkativeness=1.0
+    )
+    toml = (rc.room_dir / "room.toml").read_text(encoding="utf-8")
+    assert "talkativeness" not in toml

--- a/tests/test_p16_schedule_talkativeness.py
+++ b/tests/test_p16_schedule_talkativeness.py
@@ -1,0 +1,468 @@
+"""P16：发言权重（``[[guest]].talkativeness``）+ 手动档（``[room].schedule_mode``）。
+
+复现优先，覆盖 docs/P16-发言权重与手动模式.md「测试计划」：
+
+- 配置校验：schedule_mode 白名单（暂缓 round_robin/pooled 分诊）、talkativeness 数值/
+  bool/越界、缺省透 None / 默认 scoring。
+- talkativeness 偏置：effective=clamp(base×talk)、no-op、reclamp、base=0、0.0 不被吞、
+  不作用 @/broadcast。
+- manual：auto-pick 恒空 + IntentScorer 零调用 + @/broadcast 仍路由 + scoring_path=manual。
+- schedule_mode 串接（专用字段非 overrides）+ explicit 入参优先钉点。
+- 取证显式穿透：record_scoring 落盘 base_score/talkativeness；data.scores 仅 effective。
+- round-trip toml：写 schedule_mode/talkativeness → reload 保住；默认不写盘。
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from chahua import admin
+from chahua._persist import read_jsonl_skip_bad
+from chahua.admin_room import _room_config_to_dict
+from chahua.admin_toml import _render_room_toml
+from chahua.config import RoomConfigError, load_room_config
+from chahua.cursor import GuestCursor
+from chahua.debug_recorder import (
+    SCORING_PATH_BROADCAST,
+    SCORING_PATH_MANUAL,
+    SCORING_PATH_MENTION,
+    SCORING_PATH_SCORING,
+    TurnRecorder,
+)
+from chahua.events import ChahuaEnvelope, ChahuaEventType
+from chahua.orchestrator import Orchestrator, OrchestratorConfig
+from chahua.orchestrator_config import (
+    SCHEDULE_MODE_MANUAL,
+    SCHEDULE_MODE_SCORING,
+)
+from chahua.room import Room
+from chahua.scoring import IntentScorer, ScoreKind
+from chahua.session import _make_orchestrator_config
+from chahua.summarizer import Summarizer
+from chahua.user_md import USER_SPEAKER_ID, UserConfig
+
+from conftest import (
+    FixedScorer,
+    NoopSummarizer,
+    SpeakingStubGuest,
+    StubGuest,
+    build_orch,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+class CountingScorer(FixedScorer):
+    """FixedScorer + 调用计数 —— manual 档断言 IntentScorer 零调用。"""
+
+    def __init__(self, scores: dict[str, float]) -> None:
+        super().__init__(scores)
+        self.calls = 0
+
+    async def score(self, **kw):
+        self.calls += 1
+        return await super().score(**kw)
+
+    async def score_with_prompt(self, **kw):
+        self.calls += 1
+        return await super().score_with_prompt(**kw)
+
+
+def _orch(scores, *, talk=None, mode=None, scorer=None):
+    """build_orch + 可选 per-guest talkativeness + schedule_mode 热替。"""
+    orch = build_orch(*scores.keys(), scorer=scorer or FixedScorer(scores))
+    if talk:
+        orch.update_talkativeness(talk)
+    if mode:
+        orch.set_config(dataclasses.replace(orch.config, schedule_mode=mode))
+    return orch
+
+
+async def _pick(orch, text="随便聊聊"):
+    orch.room.append(USER_SPEAKER_ID, text)
+    return await orch._pick_next_speaker(respect_at_mention=True)
+
+
+def _seed_room(env_paths, room_id="p16"):
+    return admin.create_room(
+        paths=env_paths, room_id=room_id, name=room_id,
+        guests=[{"persona": "chahua/personas/宝总/宝总.md", "name": "宝总"}],
+    )
+
+
+def _write_room(rc, *, room_extra="", guest_extra="") -> None:
+    body = (
+        '[room]\nname = "x"\n'
+        + room_extra
+        + '\n\n[[guest]]\nname = "宝总"\n'
+        'persona = "chahua/personas/宝总/宝总.md"\npermission = "read-only"\n'
+        + guest_extra
+        + "\n"
+    )
+    (rc.room_dir / "room.toml").write_text(body, encoding="utf-8")
+
+
+# ── 配置校验：schedule_mode ───────────────────────────────────────────────────
+
+
+def test_schedule_mode_missing_defaults_scoring(env_paths):
+    rc = _seed_room(env_paths)
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    assert rc2.schedule_mode == SCHEDULE_MODE_SCORING
+
+
+def test_schedule_mode_manual_parses(env_paths):
+    rc = _seed_room(env_paths)
+    _write_room(rc, room_extra='schedule_mode = "manual"')
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    assert rc2.schedule_mode == SCHEDULE_MODE_MANUAL
+
+
+def test_schedule_mode_not_in_orchestrator_overrides(env_paths):
+    """专用字段——不能漏进 orchestrator_overrides 数值表（防"白名单允许但被忽略"）。"""
+    rc = _seed_room(env_paths)
+    _write_room(rc, room_extra='schedule_mode = "manual"')
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    assert "schedule_mode" not in rc2.orchestrator_overrides
+
+
+def test_schedule_mode_deferred_round_robin_rejected(env_paths):
+    """round_robin/pooled 暂缓 → "暂未实现"分诊（区别于拼错）。"""
+    rc = _seed_room(env_paths)
+    _write_room(rc, room_extra='schedule_mode = "round_robin"')
+    with pytest.raises(RoomConfigError, match=r"暂未实现"):
+        load_room_config(rc.room_dir, paths=env_paths)
+
+
+def test_schedule_mode_typo_rejected(env_paths):
+    rc = _seed_room(env_paths)
+    _write_room(rc, room_extra='schedule_mode = "manaul"')
+    with pytest.raises(RoomConfigError, match=r"非法"):
+        load_room_config(rc.room_dir, paths=env_paths)
+
+
+def test_schedule_mode_non_string_rejected(env_paths):
+    rc = _seed_room(env_paths)
+    _write_room(rc, room_extra="schedule_mode = 1")
+    with pytest.raises(RoomConfigError, match=r"schedule_mode.*字符串"):
+        load_room_config(rc.room_dir, paths=env_paths)
+
+
+# ── 配置校验：talkativeness ───────────────────────────────────────────────────
+
+
+def test_talkativeness_missing_is_none(env_paths):
+    """缺字段 → None（未显式选；消费侧 coalesce 1.0）。"""
+    rc = _seed_room(env_paths)
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    assert rc2.guests[0].talkativeness is None
+
+
+def test_talkativeness_explicit_value(env_paths):
+    rc = _seed_room(env_paths)
+    _write_room(rc, guest_extra="talkativeness = 1.8")
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    assert rc2.guests[0].talkativeness == 1.8
+
+
+def test_talkativeness_explicit_zero_kept(env_paths):
+    """0.0 是合法显式值（哑茶客），不被当缺省。"""
+    rc = _seed_room(env_paths)
+    _write_room(rc, guest_extra="talkativeness = 0.0")
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    assert rc2.guests[0].talkativeness == 0.0
+
+
+def test_talkativeness_int_promotes(env_paths):
+    rc = _seed_room(env_paths)
+    _write_room(rc, guest_extra="talkativeness = 2")
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    assert rc2.guests[0].talkativeness == 2.0
+
+
+def test_talkativeness_bool_rejected(env_paths):
+    rc = _seed_room(env_paths)
+    _write_room(rc, guest_extra="talkativeness = true")
+    with pytest.raises(RoomConfigError, match=r"talkativeness.*数值"):
+        load_room_config(rc.room_dir, paths=env_paths)
+
+
+def test_talkativeness_out_of_range_rejected(env_paths):
+    rc = _seed_room(env_paths)
+    _write_room(rc, guest_extra="talkativeness = 5.0")
+    with pytest.raises(RoomConfigError, match=r"talkativeness.*越界"):
+        load_room_config(rc.room_dir, paths=env_paths)
+
+
+def test_talkativeness_negative_rejected(env_paths):
+    rc = _seed_room(env_paths)
+    _write_room(rc, guest_extra="talkativeness = -0.5")
+    with pytest.raises(RoomConfigError, match=r"talkativeness.*越界"):
+        load_room_config(rc.room_dir, paths=env_paths)
+
+
+@pytest.mark.parametrize("literal", ["nan", "inf", "-inf"])
+def test_talkativeness_non_finite_rejected(env_paths, literal):
+    """TOML 允许 ``nan`` / ``inf`` 字面量；非有限值不是合法权重（``score×NaN=NaN`` 永久静默）。
+    NaN 尤其要先于范围判（``nan<MIN`` / ``nan>MAX`` 都 False 会漏过区间检查）。"""
+    rc = _seed_room(env_paths)
+    _write_room(rc, guest_extra=f"talkativeness = {literal}")
+    with pytest.raises(RoomConfigError, match=r"talkativeness"):
+        load_room_config(rc.room_dir, paths=env_paths)
+
+
+# ── talkativeness 偏置（scoring 档）───────────────────────────────────────────
+
+
+async def test_talk_default_no_op():
+    """talk=1.0 严格 no-op：0.7 ≥ 0.45 → winner，score 不变。"""
+    orch = _orch({"宝总": 0.7, "陶陶": 0.3})
+    winners, scores, _, meta = await _pick(orch)
+    assert winners == ["宝总"]
+    by = {s.guest_name: s for s in scores}
+    assert by["宝总"].score == 0.7
+    assert by["宝总"].base_score == 0.7
+    assert by["宝总"].talkativeness == 1.0
+
+
+async def test_talk_damp_drops_below_threshold():
+    """damp：0.8 × 0.5 = 0.4 < 0.45 → 相关话题也忍住。"""
+    orch = _orch({"宝总": 0.8}, talk={"宝总": 0.5})
+    winners, scores, _, _ = await _pick(orch)
+    assert winners == []
+    s = scores[0]
+    assert s.base_score == 0.8
+    assert s.score == pytest.approx(0.4)
+    assert s.talkativeness == 0.5
+
+
+async def test_talk_boost_lifts_above_threshold():
+    """boost：0.3 × 1.8 = 0.54 ≥ 0.45 → 话痨插进来。"""
+    orch = _orch({"陶陶": 0.3}, talk={"陶陶": 1.8})
+    winners, scores, _, _ = await _pick(orch)
+    assert winners == ["陶陶"]
+    assert scores[0].score == pytest.approx(0.54)
+    assert scores[0].base_score == 0.3
+
+
+async def test_talk_reclamp_caps_at_one():
+    """reclamp：0.8 × 2.0 = 1.6 → 1.0。"""
+    orch = _orch({"陶陶": 0.8}, talk={"陶陶": 2.0})
+    _, scores, _, _ = await _pick(orch)
+    assert scores[0].score == 1.0
+    assert scores[0].base_score == 0.8
+
+
+async def test_talk_base_zero_stays_zero():
+    """乘性：base=0（话题无关）再高权重仍 0 —— "爱说话"≠"乱插话"。"""
+    orch = _orch({"陶陶": 0.0}, talk={"陶陶": 4.0})
+    winners, scores, _, _ = await _pick(orch)
+    assert winners == []
+    assert scores[0].score == 0.0
+
+
+async def test_talk_explicit_zero_mutes():
+    """显式 0.0：相关话题也哑（0.9 × 0.0 = 0）。"""
+    orch = _orch({"宝总": 0.9}, talk={"宝总": 0.0})
+    winners, scores, _, _ = await _pick(orch)
+    assert winners == []
+    assert scores[0].score == 0.0
+    assert scores[0].talkativeness == 0.0
+
+
+async def test_talk_not_applied_to_mention():
+    """被 @ 的高冷茶客仍 score=1.0 入选 —— talkativeness 不缩放路由信号。"""
+    orch = _orch({"宝总": 0.7, "陶陶": 0.3}, talk={"宝总": 0.0})
+    orch.room.append(USER_SPEAKER_ID, "@宝总 你怎么看")
+    winners, scores, _, meta = await orch._pick_next_speaker(respect_at_mention=True)
+    assert winners == ["宝总"]
+    assert scores[0].score == 1.0
+    assert scores[0].kind == ScoreKind.MENTION
+    assert meta.scoring_path == SCORING_PATH_MENTION
+
+
+async def test_talk_not_applied_to_broadcast():
+    """@all 全员各一次，哑茶客也带上（score=1.0），talkativeness 不缩放。"""
+    orch = _orch({"宝总": 0.7, "陶陶": 0.3}, talk={"宝总": 0.0, "陶陶": 0.0})
+    orch.room.append(USER_SPEAKER_ID, "@all 都说一句")
+    winners, scores, _, meta = await orch._pick_next_speaker(respect_at_mention=True)
+    assert set(winners) == {"宝总", "陶陶"}
+    assert all(s.score == 1.0 for s in scores)
+    assert meta.scoring_path == SCORING_PATH_BROADCAST
+
+
+# ── manual 档 ─────────────────────────────────────────────────────────────────
+
+
+async def test_manual_auto_pick_empty_and_zero_scoring():
+    """manual：auto-pick 恒空 + IntentScorer 零调用。"""
+    scorer = CountingScorer({"宝总": 0.9, "陶陶": 0.9})
+    orch = _orch({"宝总": 0.9, "陶陶": 0.9}, mode=SCHEDULE_MODE_MANUAL, scorer=scorer)
+    winners, scores, prompts, meta = await _pick(orch)
+    assert winners == []
+    assert scores == []
+    assert prompts == {}
+    assert meta.scoring_path == SCORING_PATH_MANUAL
+    assert scorer.calls == 0
+
+
+async def test_manual_ai_relay_also_empty():
+    """manual 下连 AI 接力（respect_at_mention=False）都恒空。"""
+    scorer = CountingScorer({"宝总": 0.9})
+    orch = _orch({"宝总": 0.9}, mode=SCHEDULE_MODE_MANUAL, scorer=scorer)
+    orch.room.append(USER_SPEAKER_ID, "hi")
+    winners, _, _, meta = await orch._pick_next_speaker(respect_at_mention=False)
+    assert winners == []
+    assert meta.scoring_path == SCORING_PATH_MANUAL
+    assert scorer.calls == 0
+
+
+async def test_manual_mention_still_routes():
+    """manual 下 @宝总 仍确定性路由一句。"""
+    scorer = CountingScorer({"宝总": 0.0, "陶陶": 0.0})
+    orch = _orch({"宝总": 0.0, "陶陶": 0.0}, mode=SCHEDULE_MODE_MANUAL, scorer=scorer)
+    orch.room.append(USER_SPEAKER_ID, "@宝总 你怎么看")
+    winners, _, _, meta = await orch._pick_next_speaker(respect_at_mention=True)
+    assert winners == ["宝总"]
+    assert meta.scoring_path == SCORING_PATH_MENTION
+    assert scorer.calls == 0
+
+
+async def test_manual_broadcast_still_routes():
+    """manual 下 @all 仍全员一次。"""
+    orch = _orch({"宝总": 0.0, "陶陶": 0.0}, mode=SCHEDULE_MODE_MANUAL)
+    orch.room.append(USER_SPEAKER_ID, "@all 都说一句")
+    winners, _, _, meta = await orch._pick_next_speaker(respect_at_mention=True)
+    assert set(winners) == {"宝总", "陶陶"}
+    assert meta.scoring_path == SCORING_PATH_BROADCAST
+
+
+# ── schedule_mode 串接 + explicit 优先 ────────────────────────────────────────
+
+
+def test_make_orch_config_threads_schedule_mode():
+    cfg = _make_orchestrator_config({}, schedule_mode=SCHEDULE_MODE_MANUAL)
+    assert cfg.schedule_mode == SCHEDULE_MODE_MANUAL
+
+
+def test_make_orch_config_default_scoring():
+    cfg = _make_orchestrator_config({})
+    assert cfg.schedule_mode == SCHEDULE_MODE_SCORING
+
+
+def test_make_orch_config_keeps_numeric_overrides():
+    """schedule_mode 穿参不影响数值 override patch。"""
+    cfg = _make_orchestrator_config(
+        {"want_threshold": 0.6}, schedule_mode=SCHEDULE_MODE_MANUAL
+    )
+    assert cfg.want_threshold == 0.6
+    assert cfg.schedule_mode == SCHEDULE_MODE_MANUAL
+
+
+def test_make_orch_config_explicit_wins():
+    """钉点：explicit SDK 入参完全优先，自带 schedule_mode 不被 schedule_mode= 覆盖。"""
+    explicit = OrchestratorConfig(schedule_mode=SCHEDULE_MODE_SCORING)
+    cfg = _make_orchestrator_config(
+        {}, schedule_mode=SCHEDULE_MODE_MANUAL, explicit=explicit
+    )
+    assert cfg is explicit
+    assert cfg.schedule_mode == SCHEDULE_MODE_SCORING
+
+
+def test_build_session_manual_takes_effect(env_paths):
+    """端到端：room.toml schedule_mode=manual → OrchestratorConfig.schedule_mode=manual。"""
+    from chahua.session import build_room_session
+
+    rc = _seed_room(env_paths, room_id="p16-manual")
+    _write_room(rc, room_extra='schedule_mode = "manual"')
+    session = build_room_session(rc.room_dir, env_paths)
+    try:
+        assert session.orchestrator.config.schedule_mode == SCHEDULE_MODE_MANUAL
+    finally:
+        session.close()
+
+
+# ── 取证显式穿透 ──────────────────────────────────────────────────────────────
+
+
+def _build_orch_with_recorder(room, scorer, rec):
+    return Orchestrator(
+        room=room,
+        user_config=UserConfig(display_name="测试者", full_md=None, source=None),
+        scorer=scorer,
+        summarizer=NoopSummarizer(),
+        cursor=GuestCursor(),
+        config=OrchestratorConfig(
+            max_consecutive_ai_turns=1, max_speakers_per_pick=1,
+            summary_block_size=999,
+        ),
+        recorder=rec,
+    )
+
+
+async def test_forensics_punch_through(tmp_path: Path):
+    """record_scoring 落盘补 base_score/talkativeness（仅 SCORED 且 talk≠1.0）；
+    talk=1.0 省略；实时 data.scores 仅 effective、不含 base_score。"""
+    room = Room(name="r-forensics")
+    room.add_participant(USER_SPEAKER_ID)
+    rec = TurnRecorder(tmp_path, enabled=True, capture_prompts=False)
+    scorer = FixedScorer({"A": 0.9, "B": 0.8})
+    orch = _build_orch_with_recorder(room, scorer, rec)
+    # A talk=1.0（no-op，winner）；B talk=0.5（eff 0.4，loser）。
+    orch.register(SpeakingStubGuest("A", room, rec), persona_md="A", talkativeness=1.0)
+    orch.register(SpeakingStubGuest("B", room, rec), persona_md="B", talkativeness=0.5)
+
+    captured: list[ChahuaEnvelope] = []
+    await orch.submit_user_message("你好", sink=captured.append)
+
+    rows = list(read_jsonl_skip_bad(tmp_path / "debug" / "turns.jsonl"))
+    assert len(rows) == 1
+    by_guest = {r["guest"]: r for r in rows[0]["scoring"]["results"]}
+    # B 被偏置：落盘有 base_score / talkativeness，score 是 effective。
+    assert by_guest["B"]["base_score"] == 0.8
+    assert by_guest["B"]["talkativeness"] == 0.5
+    assert by_guest["B"]["score"] == pytest.approx(0.4)
+    # A talk=1.0：no-op，省略 base_score / talkativeness 两 key。
+    assert "base_score" not in by_guest["A"]
+    assert "talkativeness" not in by_guest["A"]
+
+    # 实时 turn_start data.scores 仅 effective，绝不含 base_score。
+    starts = [e for e in captured if e.type == ChahuaEventType.TURN_START]
+    assert starts
+    score_dicts = {d["guest_name"]: d for d in starts[0].data["scores"]}
+    assert score_dicts["B"]["score"] == pytest.approx(0.4)
+    assert "base_score" not in score_dicts["B"]
+    assert "talkativeness" not in score_dicts["B"]
+
+
+# ── round-trip toml ───────────────────────────────────────────────────────────
+
+
+def test_round_trip_preserves_non_default(env_paths):
+    """schedule_mode=manual + 显式 talkativeness（含 0.0）→ reload 保住。"""
+    rc = _seed_room(env_paths, room_id="p16-rt")
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    # 手工拼一个非默认 RoomConfig 经 snapshot → render → reload。
+    snap = _room_config_to_dict(rc2, env_paths)
+    snap["schedule_mode"] = SCHEDULE_MODE_MANUAL
+    snap["guests"][0]["talkativeness"] = 0.0
+    (rc.room_dir / "room.toml").write_text(
+        _render_room_toml(snap), encoding="utf-8"
+    )
+    reloaded = load_room_config(rc.room_dir, paths=env_paths)
+    assert reloaded.schedule_mode == SCHEDULE_MODE_MANUAL
+    assert reloaded.guests[0].talkativeness == 0.0
+
+
+def test_round_trip_defaults_not_written(env_paths):
+    """默认 scoring / 未填 talkativeness 不写盘（保持 toml 简洁）。"""
+    rc = _seed_room(env_paths, room_id="p16-rt-def")
+    rc2 = load_room_config(rc.room_dir, paths=env_paths)
+    snap = _room_config_to_dict(rc2, env_paths)
+    rendered = _render_room_toml(snap)
+    assert "schedule_mode" not in rendered
+    assert "talkativeness" not in rendered

--- a/tests/test_server_inbound.py
+++ b/tests/test_server_inbound.py
@@ -40,8 +40,10 @@ from chahua.server import (
     INBOUND_UPDATE_GUEST_ISOLATION,
     INBOUND_UPDATE_GUEST_LLM,
     INBOUND_UPDATE_GUEST_PERMISSION,
+    INBOUND_UPDATE_GUEST_TALKATIVENESS,
     INBOUND_UPDATE_ROOM_LLM,
     INBOUND_UPDATE_ROOM_ORCHESTRATOR,
+    INBOUND_UPDATE_ROOM_SCHEDULE_MODE,
     INBOUND_UPDATE_ROOM_TOML,
     INBOUND_UPDATE_USER_AVATAR,
     INBOUND_UPDATE_USER_MD,
@@ -103,6 +105,15 @@ class _SpyAdmin(AdminHandlers):
 
     def _update_room_orchestrator(self, *, overrides, sink):
         self.server.calls.append(("_update_room_orchestrator", {"overrides": overrides}))
+
+    def _update_room_schedule_mode(self, *, mode, sink):
+        self.server.calls.append(("_update_room_schedule_mode", {"mode": mode}))
+
+    def _update_guest_talkativeness(self, *, name, talkativeness, sink):
+        self.server.calls.append((
+            "_update_guest_talkativeness",
+            {"name": name, "talkativeness": talkativeness},
+        ))
 
     def _update_room_llm(self, *, section, spec_dict, sink):
         self.server.calls.append((
@@ -452,6 +463,72 @@ async def test_update_room_orchestrator_empty_overrides_dispatches(srv: _SpyServ
     {"type": INBOUND_UPDATE_ROOM_ORCHESTRATOR, "overrides": "want=0.5"},  # str
 ])
 async def test_update_room_orchestrator_bad_payload(srv: _SpyServer, payload):
+    await srv._handle_inbound(payload, _sink)
+    assert srv.calls == []
+    assert srv.cancel_drain_count == 0
+
+
+# ── P16: update_room_schedule_mode / update_guest_talkativeness ────────────
+
+
+async def test_update_room_schedule_mode_ok(srv: _SpyServer):
+    """schedule_mode 轻热替 —— 走 swap_room_config，不 cancel in-flight。"""
+    await srv._handle_inbound(
+        {"type": INBOUND_UPDATE_ROOM_SCHEDULE_MODE, "mode": "manual"}, _sink,
+    )
+    assert srv.cancel_drain_count == 0
+    assert srv.calls == [("_update_room_schedule_mode", {"mode": "manual"})]
+
+
+@pytest.mark.parametrize("payload", [
+    {"type": INBOUND_UPDATE_ROOM_SCHEDULE_MODE},                  # 没 mode
+    {"type": INBOUND_UPDATE_ROOM_SCHEDULE_MODE, "mode": None},    # null
+    {"type": INBOUND_UPDATE_ROOM_SCHEDULE_MODE, "mode": 1},       # 非 str
+])
+async def test_update_room_schedule_mode_bad_payload(srv: _SpyServer, payload):
+    """wire 层只挡类型 —— 白名单（manual/scoring）校验在 admin 层（不在路由测覆盖）。"""
+    await srv._handle_inbound(payload, _sink)
+    assert srv.calls == []
+    assert srv.cancel_drain_count == 0
+
+
+async def test_update_guest_talkativeness_ok(srv: _SpyServer):
+    """talkativeness 轻热替 —— 不 cancel、不重建茶客。"""
+    await srv._handle_inbound(
+        {
+            "type": INBOUND_UPDATE_GUEST_TALKATIVENESS,
+            "name": "宝总", "talkativeness": 1.8,
+        },
+        _sink,
+    )
+    assert srv.cancel_drain_count == 0
+    assert srv.calls == [(
+        "_update_guest_talkativeness", {"name": "宝总", "talkativeness": 1.8},
+    )]
+
+
+async def test_update_guest_talkativeness_int_promotes(srv: _SpyServer):
+    """整数 promote 到 float（wire 层）。"""
+    await srv._handle_inbound(
+        {"type": INBOUND_UPDATE_GUEST_TALKATIVENESS, "name": "宝总", "talkativeness": 2},
+        _sink,
+    )
+    assert srv.calls == [(
+        "_update_guest_talkativeness", {"name": "宝总", "talkativeness": 2.0},
+    )]
+
+
+@pytest.mark.parametrize("payload", [
+    {"type": INBOUND_UPDATE_GUEST_TALKATIVENESS, "talkativeness": 1.0},        # 没 name
+    {"type": INBOUND_UPDATE_GUEST_TALKATIVENESS, "name": "宝总"},               # 没 talkativeness
+    {"type": INBOUND_UPDATE_GUEST_TALKATIVENESS, "name": "宝总", "talkativeness": "x"},   # 非数值
+    {"type": INBOUND_UPDATE_GUEST_TALKATIVENESS, "name": "宝总", "talkativeness": True},  # bool
+    # NaN / inf —— json.loads 默认收这些 token，wire 层 require_number 必须挡（否则
+    # NaN 漏过下游范围判 → 永久静默茶客 + "nan" 落 toml）。
+    {"type": INBOUND_UPDATE_GUEST_TALKATIVENESS, "name": "宝总", "talkativeness": float("nan")},
+    {"type": INBOUND_UPDATE_GUEST_TALKATIVENESS, "name": "宝总", "talkativeness": float("inf")},
+])
+async def test_update_guest_talkativeness_bad_payload(srv: _SpyServer, payload):
     await srv._handle_inbound(payload, _sink)
     assert srv.calls == []
     assert srv.cancel_drain_count == 0


### PR DESCRIPTION
## 摘要

P16 调度体验小步增强。反向评审（对照现有 `@mention` / task goal order_hint / handoff panel）后，从草线四模式收敛为两件填真空洞的旋钮，均走 `swap_room_config` **轻热替**（下一轮 pick 当场生效、不 cancel in-flight、不重建茶客），区别于 permission/isolation/LLM 的 `_replace_session` 重建。

- **`[[guest]].talkativeness`**（默认 1.0，范围 `[0,4]`）：`scoring` 档 auto-pick 的 per-guest 乘性偏置 `effective = clamp(base × talk, 0, 1)`。只影响自发接话；`@`提及 / broadcast / handoff / MTS / cooldown / 打分 prompt 全不动。乘性 → `base=0` 再高权重仍 0（「爱说话」≠「乱插话」）。
- **`[room].schedule_mode ∈ {scoring, manual}`**：`manual` 档 auto-pick 第 3 档恒空 + 零打分 LLM 调用（真增量是成本不是行为，≈ `want_threshold=1.0` 但跳过每 pick 的 N 次打分）。`@` / handoff / MTS 照常。
- `round_robin` / `pooled` 暂缓（冗余于 `@all`+`panel` / 撞取证回放）。

设计文档：`docs/P16-发言权重与手动模式.md`。

## M1 机制闭环
config 定义+校验 → session 装配穿参（`_make_orchestrator_config(overrides, *, schedule_mode=, explicit=)`，**explicit SDK 入参完全优先**）→ `pick_next_speaker` 分派 + scoring 偏置 → 取证显式穿透（`ScoreResult.base_score`/`talkativeness` 仅载体，`record_scoring` 补 key，实时 `data.scores` 仍 effective-only）→ `admin_toml` 回写（默认 `scoring`/`1.0` 不写盘，显式 `0.0` 保留）。`scoring_path` 加 `manual` 值，全程不 bump `schema_version`。

## M2 发布面
room snapshot 加 `schedule_mode`（room 顶层）/ `talkativeness`（guest dict）；`update_room_schedule_mode` / `update_guest_talkativeness` inbound + **轻热替 handler**（不 `_replace_session`、不 cancel）+ mutator（写盘前校验）；room「手动模式」checkbox + guest 0–4 滑杆。

## 评审与加固
两轮独立对抗评审。修了 **NaN 绕过**：`nan < MIN` / `nan > MAX` 都为 False 会漏过区间检查，而 `json.loads` 默认收 `NaN` token、`repr(nan)` 是合法 TOML 字面量 → 会让 `score × NaN = NaN` 永久静默茶客并落盘。三处 `isfinite` 防御（wire `require_number` / config `_build_talkativeness` / mutator）+ 测试。

## 测试
全量 **1541 passed**。新增 `tests/test_p16_schedule_talkativeness.py`（35）+ `tests/test_p16_m2_inbound.py`（14）+ `test_server_inbound.py` 路由测扩充。承重不变量同步进 `CLAUDE.md`「发言权重与手动模式（P16）」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)