### PR TITLE
发布 v0.1.8 —— 发言权重与手动调度档（P16）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-06-19
+
+详见 [`docs/releases/v0.1.8.md`](docs/releases/v0.1.8.md)。
+
+### Added
+- **P16 发言权重与手动模式 —— `talkativeness` + `schedule_mode`**（2026-06-19，详见 [`docs/P16-发言权重与手动模式.md`](docs/P16-发言权重与手动模式.md)）：给意愿打分调度补两个简单旋钮，反向评审后从草线四模式收敛为两件填真空洞的，**均走 `swap_room_config` 轻热替**（下一轮 pick 当场生效、不 cancel in-flight、不重建茶客）。① **`[[guest]].talkativeness`**（默认 `1.0`、范围 `[0.0,4.0]`）：`scoring` 档 auto-pick 的 per-guest 乘性偏置 `effective = clamp(base_score × talkativeness, 0, 1)`——让茶客「主咖」/「高冷」/「自发时哑」，不改人设、确定可调、持久。乘性而非加性（`base=0` 再高权重仍 0，「爱说话」≠「乱插话」）；只影响自发接话，`@`提及 / broadcast / handoff / MTS / cooldown / 打分 prompt **全不动**。② **`[room].schedule_mode ∈ {scoring, manual}`**：`manual` 档 auto-pick 第 3 档**恒空 + 零打分 LLM 调用**，真增量是成本不是行为（≈ `want_threshold=1.0` 但跳过每 pick N 次打分）；`@` / handoff / MTS 照常。**M1 机制闭环**：配置四点闭环 + `schedule_mode` 经 `_make_orchestrator_config(overrides, *, schedule_mode=, explicit=)` 装配（显式 SDK `explicit` 入参完全优先、不混 `orchestrator_overrides`）+ 取证显式穿透（`ScoreResult.base_score`/`talkativeness` 仅载体，`record_scoring` 补 key，实时 `data.scores` 仍 effective-only，`scoring_path` 加 `manual`，不 bump `schema_version`）+ 默认 coalesce 防坑（`x if x is not None else 1.0`、禁 `or 1.0`，范围 `[0,4]` + 拒非有限值 NaN/inf）。**M2 发布面**：room snapshot 加两字段 + `update_room_schedule_mode` / `update_guest_talkativeness` inbound（轻热替 handler，不 `_replace_session`、不 cancel）+ mutator（写盘前校验、默认不写、显式 `0.0` 保留）+ room checkbox + guest 0–4 滑杆。`round_robin` / `pooled` 暂缓。经两轮独立对抗评审收敛（M2 NaN 绕过加固）。1541 测试全过（+62）。
+
 ## [0.1.7] - 2026-06-17
 
 详见 [`docs/releases/v0.1.7.md`](docs/releases/v0.1.7.md)。

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.8-dev",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.8-dev",
+      "version": "0.1.8",
       "dependencies": {
         "@highlightjs/cdn-assets": "^11.11.1",
         "dompurify": "^3.4.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.8-dev",
+  "version": "0.1.8",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.8.dev0"
+__version__ = "0.1.8"

--- a/docs/releases/v0.1.8.md
+++ b/docs/releases/v0.1.8.md
@@ -1,0 +1,37 @@
+# v0.1.8 —— 发言权重与手动调度档（P16）（2026-06-19）
+
+继 v0.1.7「桌面登录态注入凭证 + 聊天富渲染 + 系统 prompt 英文化」之后第九个版本。本版单条主线：**P16 发言权重与手动模式**——给意愿打分调度补两个简单旋钮，方便不同场景，又不把 ChaHua 改成通用 Agent 框架。经反向评审（对照现有 `@mention` / task goal order_hint / handoff panel 调度面）后，从草线四模式收敛为两件填真空洞的旋钮，**均走 `swap_room_config` 轻热替**（下一轮 pick 当场生效、不 cancel in-flight、不重建茶客），区别于 permission/isolation/LLM 的 `_replace_session` 重建。1541 测试全过（v0.1.7 收线 1479 → +62）。
+
+## 亮点
+
+- **`[[guest]].talkativeness` —— 茶客级「音量旋钮」**：默认 `1.0`、范围 `[0.0, 4.0]`，是 `scoring` 档 auto-pick 的 per-guest **乘性偏置** `effective = clamp(base_score × talkativeness, 0, 1)`。让某位茶客「主咖」（>1 爱抢）或「高冷」（<1 忍住）或「自发时哑」（`0.0`），**不改人设、确定可调、持久生效**。乘性而非加性 —— `base=0`（话题完全无关）再高权重仍是 0（「爱说话」≠「乱插话」）。只影响自发接话：`@`提及 / broadcast / handoff / MTS / cooldown 门 / 打分 prompt **全不动**。
+- **`[room].schedule_mode ∈ {scoring, manual}` —— 房间级总开关**：`manual` 档 `pick_next_speaker` 第 3 档**恒空 + 零打分 LLM 调用**——茶客永不自发接话，普通消息无人理立即等用户。真增量是**成本不是行为**（≈ `want_threshold=1.0` 但跳过每 pick 的 N 次打分），给贵模型房间「待命且免费」、强控房间「我点谁谁说」、纯 handoff / MTS 驱动的工作房间用。`@宝总` / `@all` / handoff / 托管会话在 `manual` 下照常工作。
+- **轻热替、不重建**：两个旋钮都是声明性配置字段、不改 cwd / LLM client / agent 实例，走 `swap_room_config`（`schedule_mode` 进 `OrchestratorConfig`、`talkativeness` 刷 `_GuestEntry`）——茶客 agentao 实例 / 进程内对话窗口 / 记忆全不动，「边拨边看」即时生效。M2 起 room 设置加「手动模式」checkbox、guest 设置加 0–4 滑杆（实时数字、manual 档置灰），与既有 per-guest 设置面板一致，**不再要用户手改 toml**。
+- **不引入新控制流轴**：档只换 auto-pick 这一档；`@` 确定性路由、handoff（delegate/review/panel）、MTS 全部正交不动（后两者跑 `run_pending_handoff` drain loop、不经 auto-pick）。不引入策略插件 / 图编排 DSL / 中央调度员 LLM call。`round_robin`（冗余于 `@all`+`panel`、且自我矛盾于「打分>固定轮询」）/ `pooled`（非确定性撞取证回放）双双暂缓。
+
+## 里程碑（按提交序）
+
+- **P16 发言权重与手动模式 —— `talkativeness` + `schedule_mode`**（提交 `be7e23f`，2026-06-19，详见 [`docs/P16-发言权重与手动模式.md`](../P16-发言权重与手动模式.md)）：
+  - **M1 机制闭环**：配置四点闭环（`config.py` 定义+校验 → `session.py` 装配穿参 → `pick_next_speaker` 分派+偏置 → `admin_toml` 回写）。`schedule_mode` 经 `_make_orchestrator_config(overrides, *, schedule_mode=, explicit=)` 装配——**显式 SDK `explicit` 入参完全优先**（自带 schedule_mode、不被覆盖、守 P15 起的「显式入参优先」契约）、**不混 `orchestrator_overrides` 数值表**。
+  - **取证显式穿透**：`ScoreResult.base_score` / `talkativeness` 仅取证载体——实时 envelope `data.scores` 只发 effective `score`；要看 raw×talk 须 `record_scoring` entry 显式补 key（仅 `SCORED` 且 `talk≠1.0`）。`scoring_path` 加 `manual` 值。加字段 / key 全程**不 bump `schema_version`**。
+  - **默认 coalesce 防坑**：`talkativeness` 解析成 `Optional[float]`，use 点 `x if x is not None else 1.0`、**禁 `or 1.0`**（`0.0 or 1.0 == 1.0` 会把哑茶客吞成默认，与 permission/isolation 同坑）。范围 `[0,4]` + **拒非有限值**（NaN/inf）——TOML 允许 `nan` 字面量、`score × NaN = NaN` 会让茶客永久静默且 `repr(nan)` 落盘。
+  - **M2 发布面**：room snapshot 加 `schedule_mode`（room 顶层）/ `talkativeness`（guest dict）；`update_room_schedule_mode` / `update_guest_talkativeness` inbound + **轻热替 handler**（不 `_replace_session`、不 cancel）+ mutator（写盘前校验、默认不写盘、显式 `0.0` 保留）；前端 room checkbox + guest 0–4 滑杆。
+  - 经两轮独立对抗评审收敛（M1 docstring 纠偏 + M2 NaN 绕过加固）。
+
+## 模块新增
+
+- P16 M1 落在既有模块：`chahua/orchestrator_config.py`（`SCHEDULE_MODE_*` 常量 + `OrchestratorConfig.schedule_mode`）/ `config.py`（`RoomConfig.schedule_mode` + `GuestConfig.talkativeness` + 校验）/ `_orchestrator_scoring.py`（manual 分派 + `_apply_talkativeness` 偏置）/ `scoring.py`（`ScoreResult.base_score` / `talkativeness` 载体）/ `debug_recorder.py`（`SCORING_PATH_MANUAL` + entry 补 key）/ `session.py`（`_make_orchestrator_config` 穿参 + `swap_room_config` 刷 talkativeness）/ `orchestrator.py`（`register(*, talkativeness=)` + `update_talkativeness` + `_GuestEntry.talkativeness`）/ `admin_toml.py` + `admin_room.py`（回写保真）。
+- P16 M2 落在既有模块：`server_room_snapshot.py`（snapshot 加两字段）/ `server_inbound_admin.py`（两 inbound + 轻热替 handler）/ `admin_room.py`（`update_room_schedule_mode`）/ `admin_guest.py`（`update_guest_talkativeness`）/ `_server_helpers.py`（`require_number` + 非有限值守卫）/ `server.py`（路由）/ `app/renderer/`（`index.html` / `events.js` / `room_settings.js` / `guest_settings.js` / `renderer.js` / `styles/modal.css`）。
+
+## 文档新增 / 大改
+
+- [`docs/P16-发言权重与手动模式.md`](../P16-发言权重与手动模式.md) —— 设计 + 反向评审结论（为何砍 round_robin/pooled、为何只剩两个洞）+ M1/M2 里程碑 + 承重不变量 + 改造触点 + 测试计划。
+- [`docs/研究-同类项目与演进方向.md`](../研究-同类项目与演进方向.md) —— 同类项目调研 + ChaHua 演进方向（§四.2 调度体验小步增强指向 P16）。
+- `CLAUDE.md` —— 新增「发言权重与手动模式（P16）」承重不变量段。
+
+## 已知未做
+
+- **`round_robin` / `pooled` 暂缓**：核心「全员各一次」被 `@all` + `panel` 吃掉；`round_robin` 唯一增量「持久自动轮转」既 token 重、又恰是「打分>固定轮询」要超越的对象，自我矛盾；`pooled` 非确定性撞取证回放。真要「ambient 全员」最小动作是给 broadcast 一个 default，不是发明轮转状态机。
+- **无 persona manifest `[defaults.guest].talkativeness` 联动**：manifest 是硬编码白名单（`_ALLOWED_DEFAULTS_GUEST_KEYS = {permission, isolation}`），加 guest key 不「白送」。等「话痨人设要可分发」再补四触点。
+- **M2 前端控件为真机手测项**：room checkbox / guest 滑杆的渲染与提交在 `node --check` + 后端 inbound 测覆盖下，但 Electron 真渲染交互（滑杆拖动、manual 置灰、回显）走手测。后端零改由 `uv run pytest` 全绿兜底。
+- **packaged 安装包未 Apple Developer ID 签名**：.dmg 仍未签名（同 v0.1.3 ~ v0.1.7），首次启动需用户在「系统设置 → 隐私与安全性」放行。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.8.dev0"
+version = "0.1.8"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "chahua"
-version = "0.1.8.dev0"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "agentao" },


### PR DESCRIPTION
## 发布 v0.1.8

本版单主线 **P16 发言权重与手动模式**（`talkativeness` + `schedule_mode`，已于 #35 合并）。本 PR 是发布前置：版本号去后缀 + CHANGELOG + 发布说明。

### 改动
- **版本号五处去 `.dev` 后缀** → `0.1.8`：`pyproject.toml` / `chahua/__init__.py` / `app/package.json` / `app/package-lock.json`（2 处）/ `uv.lock`（chahua 条目）。`uv lock --check` 一致。
- **CHANGELOG**：`[Unreleased]` 填入 P16 → 改名 `## [0.1.8] - 2026-06-19` + 指向 `docs/releases/v0.1.8.md`，上方留新空 `[Unreleased]`。
- **`docs/releases/v0.1.8.md`**：体例对齐 `v0.1.7.md`（标题 / 亮点 / 里程碑按提交序 / 模块新增 / 文档 / 已知未做）。

### 验证
- 全量 `uv run pytest`：**1541 passed**（v0.1.7 收线 1479 → +62）。
- `uv lock --check` 干净。

合并后打 annotated tag `v0.1.8`、（可选）本地 `npm run build:mac` 出 dmg、`gh release create`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)