### PR TITLE
开 v0.1.9 开发周期 —— 版本号 0.1.8 → 0.1.9.dev0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.8",
+  "version": "0.1.9-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.8",
+      "version": "0.1.9-dev",
       "dependencies": {
         "@highlightjs/cdn-assets": "^11.11.1",
         "dompurify": "^3.4.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.8",
+  "version": "0.1.9-dev",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.8"
+__version__ = "0.1.9.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.8"
+version = "0.1.9.dev0"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "chahua"
-version = "0.1.8"
+version = "0.1.9.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agentao" },


### PR DESCRIPTION
v0.1.8 已发布，开 0.1.9 开发周期。版本号五处同步挂 dev 后缀：`pyproject.toml` / `chahua/__init__.py` / `app/package.json` / `app/package-lock.json`（2 处）/ `uv.lock`（chahua 条目）。`uv lock --check` 一致，无 stray `0.1.8`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)