### PR TITLE
chore(release): v0.1.10 —— P18 回溯与搜索 + 依赖大修

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-07-30
+
+详见 [`docs/releases/v0.1.10.md`](docs/releases/v0.1.10.md)。
+
+### Added
+- **P18 消息回溯（撤回未回复末条）+ 当前房历史搜索**（详见 [`docs/P18-消息回溯与历史搜索导出.md`](docs/P18-消息回溯与历史搜索导出.md)）：对齐「豆包式」长期陪伴的两个体验缺口，按**成本天差地别**分两半落地。**① 当前房搜索（M1，纯读）**——只读 `search_room` inbound → `SEARCH_RESULTS` envelope，`re.escape` + `IGNORECASE` 原文子串匹配、query 长度封顶、results 只带 `speaker_id`；命中列表点击滚动并高亮到那条消息；入口 🔍 在右侧任务面板 header（挨着 🔬 调试）。**不碰任何状态、不挡 inflight**。**② 回溯（撤回未回复的末条用户消息）**——`retract_last_user_message` inbound：**server 权威、免 `message_id`、无 payload**（严格空白名单）；三段硬校验（房间 idle 用 `busy_alive()` 而非 `_inflight_alive()`，故 bg run / dormant MTS 也算忙 ∧ transcript 末条存在且是 user ∧「其后无茶客回复」由前者蕴含）。**只截 transcript 主体，cursor 与各茶客 `agent.messages` 一律不动**；旁路同 tick 原子收尾（先 `cancel_pending_summarize()` → `Summarizer.truncate_after` → 遍历 store 全量任务的 `TaskSummaries.truncate_after` → `TurnRecorder.drop_turns_from`），末尾重发整份 room snapshot。**transcript 主体仍 append-only，`Room.truncate_last()` 是唯一全量重写入口**（`write_jsonl_atomic` tmp+rename，先写盘后弹内存）。前端撤回按钮由 MutationObserver + `endStreamingMessage` 双触发，动态挂在唯一「当前可撤回」的用户气泡上。承重不变量同步进 `CLAUDE.md` +  [`docs/INVARIANTS.md`](docs/INVARIANTS.md) §9.x。测试 +24（全量 1568 绿）。
+
+### Changed
+- **示例茶客孙博士：召回更像回忆、不像查资料**（纯 prompt 文本）：重写「关于你的记性」段，顶住两股把茶客推向 reference-lookup 的系统力（MCP 工具动词 `search` / `read_page` + 每轮 `speak_instruction` 的「review tool results / re-fetch from source」）。四条纪律：**无声地想**（禁「我查一下」这类工具前旁白，多步召回只呈现最终结果）/ **化整为言**（抖掉 `read_page` 返回的标题、`[[链接]]`、日期骨架，用人话追述）/ **信心梯度**（记得清→笃定、记得糊→自然含糊、全空→「没印象」即止）/ **禁词扩充**（加「资料」「没找到」）+ 3 组 ✗/✓ 范例钉住语域。未动 `persona.toml` / `mcp.json` / 防注入 L3。
+- **依赖 agentao `0.4.14 → 0.4.18`**：四个上游版本全是加固/修正，chahua 侧零代码改动、1568 测试全过。① `0.4.15` 会话与文件完整性——`Ctrl+C` 打断的 turn 不再让后续每轮 400（orphan `tool_calls` 回填占位结果）、`write_file` 改 tmp+rename 原子替换（不再截断即毁原文件）、无回答的 turn 被分类而非当答案发、secret 扫描器挪上实时路径。② `0.4.16` 边界加固——ACP 客户端首审（终端转义清洗 / 输出上限 / 孙进程回收）、`web_search` 撞 captcha 不再静默报「无结果」、MCP 请求带 `agentao-mcp/<version>` UA。③ `0.4.17` SDK 兼容——上游 `mcp` 2.0.0（2026-07-28 破坏性重写线上模型）会让 `0.4.16` 的**全部 MCP 路径**在新装环境上炸，`0.4.18` 同时支持 mcp 1.x / 2.x 并把依赖收敛到 `>=1.26.0,<3`。④ `0.4.18` `web_fetch` 重建（crawl4ai → Playwright + SSRF 加固）并改 `AsyncToolBase`；`Agentao.arun` 改用专属线程池、不再占用事件循环默认 executor。
+- **MCP SDK `mcp 1.27.1 → 2.0.0`**（`uv lock --upgrade-package mcp`，仍在 agentao 的 `>=1.26.0,<3` 内）：**动机是消偏斜**——`app/scripts/build-python-bundle.js` 走 `pip install`、不读 `uv.lock`，桌面包本就会现场解析到 2.x，开发环境停在 1.x 会让「我这儿能跑」与「用户装的包」跑在不同大版本上。chahua 侧**零代码改动**：全仓唯一直接触 SDK 的地方是 `chahua/mcp_thread.py` 的 `from mcp.types import Tool`，**只作类型标注、不读字段**，2.0 的 camelCase→snake_case 重命名（`inputSchema`→`input_schema` 等）碰不到；真正每轮重建 schema 的是 agentao，`0.4.17` 起用 `_compat` 探针按装好的 SDK 分流。**端到端实测**（真 `guanlan mcp --transport http`，guanlan 0.1.18 / 服务端 mcp 2.0.0）：客户端 1.27.1 与 2.0.0 两侧各跑一遍均 6 工具全列 / schema 全取到 / `search` 往返 / 干净拆除；协商出的线上协议修订**两侧同为 `2025-11-25`**，故 lock 变更不改线协议行为——**原因在客户端而非服务端**：mcp 2.0 把协议分成两个纪元（`HANDSHAKE_PROTOCOL_VERSIONS` 至 `2025-11-25` / `MODERN_PROTOCOL_VERSIONS` 仅 `2026-07-28`，后者只经带 `_meta["io.modelcontextprotocol/protocolVersion"]` 信封的无握手路径可达），连接纪元由客户端第一帧一次性锁定；agentao 的 `McpClient` 显式走 `ClientSession.initialize()`（`agentao/mcp/client.py`），而 `initialize` 提议的恒是 `LATEST_HANDSHAKE_VERSION`，故 chahua 永远落在握手纪元。实测 GuanLan 服务端 `server/discover` 自述 `['2026-07-28']`、modern 纪元开着，是我们这侧没去取。
+- **茶客子进程不再继承 agentao 的 provider 凭证**（随 agentao `0.4.15`）：shell / **stdio 型 MCP** / ACP 子进程从被擦洗的环境启动（12 个 `HARNESS_ENV_KEYS` + `LLM_PROVIDER` 隐含的那把 key），被注入的 `run_shell_command("env")` 再偷不到东西。**对 chahua 的影响面**：若某个 stdio MCP server 原先靠继承 `*_API_KEY` 工作，现在会拿到 401，需在该 server 的 `env` 块显式声明（`{"env": {"XX_API_KEY": "${XX_API_KEY}"}}`，擦洗之后才应用）或设 `AGENTAO_SCRUB_CHILD_ENV=0` 全进程恢复继承。P17 GuanLan 走 url 型 Streamable HTTP（不是子进程）**不受影响**；P15 桌面登录态注入仍只活在本进程 environ，语义不变。
+- **`CLAUDE.md` 瘦身 + 修正漂移，MTS / P11 全文下沉 `docs/INVARIANTS.md`**：「关键不变量」段只留「规则 + 关键 why」，完整 rationale / P-版本溯源 / 回归测试指引沉到 [`docs/INVARIANTS.md`](docs/INVARIANTS.md)（改不变量两处同步）；模块分工表逐条精练到「一句话职责」，顺手修掉若干条与代码已漂移的描述。新增 `app/CLAUDE.md`（动 `app/` 下文件时自动加载）承接 P10 聊天界面渲染的前端契约。纯文档，无行为改动。
+
 ## [0.1.9] - 2026-07-01
 
 详见 [`docs/releases/v0.1.9.md`](docs/releases/v0.1.9.md)。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## 常用命令
 
 ```bash
-uv sync                                       # Python 依赖（按 pyproject.toml 拉 agentao≥0.4.14）
+uv sync                                       # Python 依赖（按 pyproject.toml 拉 agentao≥0.4.18）
 uv run chahua                                 # CLI（默认入 rooms/p1-test）
 uv run chahua --room rooms/p3-黄河路
 uv run chahua-server --host 127.0.0.1 --port 7860 --room rooms/p3-黄河路  # 独跑 sidecar
@@ -46,8 +46,8 @@ Electron main (Node)  ─ spawn ─→  chahua-server (Python sidecar)
 
 职责一句话；承重契约见「关键不变量」段，实现细节看代码。
 
-- `session.py` — 房间装配。CLI 与 server 共用 `build_room_session()` / `discover_rooms()` / `load_env_files()`。
-- `config.py` — `room.toml` 解析，白名单严格（未知字段 `RoomConfigError`）。字段：`[room]` / `[room.llm]` / `[scoring]` / `[summary]` / `[[guest]]` / `[[guest.extra_mcp_servers]]`。
+- `session.py` — 房间装配。CLI 与 server 共用 `build_room_session()`。
+- `config.py` — `room.toml` 解析，白名单严格（未知字段 `RoomConfigError`）。
 - `llm_spec.py` — `LLMSpec` 三入口（`from_env` / `try_from_env` / `from_toml`）+ `build_client()`。toml 强制 `model="<provider>/<model>"`，env 允许裸 model。各 section 走自己 spec，缺即 fallback 回房间默认。
 - `guest.py` — `TeaGuest`（包 `agentao.Agentao`）。`speak()` 外层 try/except/finally 保 `message_start`/`message_end` 成对，envelope 与 transcript 共享 message_id。P13 视觉：`speak(images_rel=())` → `resolve_images` → `arun(images=...)`，懒读现传。
 - `image_input.py` — P13 视觉 helper（server inbound 与 guest 共用）。`_normalize_share_image_rel`（纯校验）+ `resolve_images`（IO：normalize → symlink 围栏 → 读 bytes → base64+MIME）。限额 `from agentao.media_limits`。
@@ -68,23 +68,21 @@ Electron main (Node)  ─ spawn ─→  chahua-server (Python sidecar)
 - `persona_summary.py` — persona 能力摘要 LLM 生成 + 内容寻址缓存（`<hash>.json`）。三级解析（手写 `summary` → 缓存 → None）；失败 WARN 不阻断。
 - `debug_recorder.py` — P6 取证落盘。`TurnRecorder` 由 orchestrator / guest / transport_bridge 三处喂。`max_turns=500` rotation 按 turn_id 整组删，`_turn_count` 内存维护永不重测盘。rotation 失败永不阻断房间。
 - `server_room_snapshot.py` — `emit_room_snapshot` 单点装配：`emit_room_info` / `emit_room_history` / `_emit_task_info` / 末尾补 MTS 快照。`turns_index` 严格 `enabled=True` 才挂；`rooms_available` 每房带 `busy=busy_alive()`；P11 加 `background_runs`。
-- `server_entry.py` — `chahua-server` CLI 入口。argparse / 端口分配 / stdin EOF watcher。
-- `admin.py` + `admin_{guest,persona,room,user,toml}.py` — admin 按域拆分：guest / persona（MCP trust / skills / P12.6 `list_installed_personas`）/ room / user / toml（`_render_room_toml` 结构化重写）。
-- `persona_import.py` — 本地 / GitHub 导入 persona 包 + P12.6 provenance 生命周期：`PersonaSource`（`.chahua-source.json`）+ `read_source` / `write_source` / `_content_hash` / `check_persona_update` / `update_persona(force=)`（`_replace_dir_atomic` 原子 swap）/ `delete_persona`。`_GitHubError` 子类 `PersonaImportError` 带 `.code` 分流 404/403。低层拆分：`persona_github.py`（GitHub Contents API 匿名客户端）/ `persona_provenance.py`（provenance 数据形状 + 读写单一来源）。
+- `persona_import.py` — 本地 / GitHub 导入 persona 包 + P12.6 provenance 生命周期。provenance 落 `.chahua-source.json`；`update_persona(force=)` 走 `_replace_dir_atomic` 原子 swap。`_GitHubError` 子类 `PersonaImportError` 带 `.code` 分流 404/403。
 - `persona_assets.py` + `trust.py` — persona sibling `mcp.json` + `skills/` 装载；MCP 走信任门（`persona-trust.json` + UI popover）。skills 软链 + copytree 兜底。
 - `mcp_thread.py` — P17 thread-backed MCP 管理器：agentao 同步 `McpClientManager` 在 ws 事件循环内 `run_until_complete` 会炸，全部 MCP async 工作挪到常驻线程（owner-task 同 task 进出 exit stack，见 P17 不变量）。
-- `persona_manifest.py` — P12 `persona.toml` 解析。`PersonaManifest` frozen dataclass（P12.6 加可选 `version` 纯展示字段）+ 三级严格白名单。两入口共享 `_parse_dict`：`load_persona_manifest`（文件）/ `parse_persona_manifest_bytes`（dry-run）。全失败统一 `PersonaManifestError`。
+- `persona_manifest.py` — P12 `persona.toml` 解析。`PersonaManifest` frozen dataclass（P12.6 加可选 `version` 纯展示字段）+ 三级严格白名单；文件与 dry-run 两入口共享 `_parse_dict`。全失败统一 `PersonaManifestError`。
 - `server.py` + `server_inbound_{admin,task,io,settings,handoff,agent_run}.py` + `_server_helpers.py` — ws 生命周期 / 帧路由 / room snapshot 在 `server.py`；30+ `_inbound_*` 切到 6 个 handler 类（组合非多继承）。`_install_handler_slots(srv)` 是装配唯一真理源；`_INBOUND_ROUTES` 帧 → 属性路径映射在 `server.py` 顶层。**改 `_inbound_*` 先看 slot 归属**。
 - `agent_run.py` + `agent_run_sink.py` + `agent_run_tools.py` — P11 后台 agent run：`AgentRun` frozen dataclass + `BatchMessageSink`（白名单过滤 + `TASK_PROPOSAL` 缓冲到 finally + `run_id` 注入）+ P11.2 茶客侧 `spawn_agent_run(s)` 工具（立即起并发后台 run，区别于等用户采纳的 `propose_*`）。`server.py::_run_agent_background` 是与 `_run_turn` 平行的 bg 执行 wrapper。
-- `handoff.py` — 调度层数据模型。`HandoffItem` frozen dataclass + `HandoffKind` enum (`DELEGATE`/`REVIEW`/`PANEL`) + 常量。本模块是「调度数据形状」单一来源。
-- `room_runtime.py` — P9 多 runtime 注册表。`RoomRuntime` 持运行态（`session` / `_inflight_turn_task` / `_managed_session` / `agent_runs` / `active_guest_names` / `_handoff_queue` 等）+ 谓词（`busy_alive` / `guest_busy` / `guest_in_bg_run` 等）。`_attach_runtime_state(runtime)` 把 `active_guest_names` 与 `_has_pending_mts_bg` 注入 orchestrator —— orch ↔ runtime 严格 1:1。
+- `handoff.py` — 调度层数据模型。本模块是「调度数据形状」单一来源。
+- `room_runtime.py` — P9 多 runtime 注册表。`RoomRuntime` 持运行态 + 谓词（`busy_alive` / `guest_busy` / `guest_in_bg_run`）。`_attach_runtime_state(runtime)` 把 `active_guest_names` 与 `_has_pending_mts_bg` 注入 orchestrator —— orch ↔ runtime 严格 1:1。
 - `message_artifacts.py` — P10 `MessageArtifactRegistry`。per-room 落 `rooms/<id>/message_artifacts.jsonl`，把 artifact rel path 反查回 originating message_id。`reset_room` clear / `/clear task` 不清。
 - `exporter.py` — 房间 transcript → markdown 导出（`export_room` inbound）。服务端拼整段 markdown + 安全文件名，前端 Blob 下载到用户机器，不写房间目录。
 
 ### WebSocket 线协议
 
 - **下行**：每帧一条 JSON = `ChahuaEnvelope.to_dict()`。
-- **上行**：每帧一条 JSON，`type` 见 `_INBOUND_ROUTES`（`user_message` / `cancel` / `switch_room` / `clear_room` / P18 `retract_last_user_message` / `fetch_turn_detail` / `list_guest_caps` / `agent_run_*` + handoff / MTS / task / admin / io（上传下载 / `export_room` / P18 `search_room` / persona 导入 2 帧 + P12.6 管理 4 帧）/ settings（含 P15 `set_llm_credentials`））。未知 `type` WARN 后忽略；非 JSON / 二进制帧 → `close(UNSUPPORTED_DATA)`。`set_llm_credentials` 严格白名单 `{provider, model, base_url?, api_key}`，未知键 NOTICE error 丢帧（敏感帧不静默吞）。
+- **上行**：每帧一条 JSON，`type` 全集见 `server.py` 顶层 `_INBOUND_ROUTES`。未知 `type` WARN 后忽略；非 JSON / 二进制帧 → `close(UNSUPPORTED_DATA)`。`set_llm_credentials` 严格白名单 `{provider, model, base_url?, api_key}`，未知键 NOTICE error 丢帧（敏感帧不静默吞）。
 
 ## 关键不变量
 
@@ -250,13 +248,7 @@ Electron main (Node)  ─ spawn ─→  chahua-server (Python sidecar)
 
 ### 聊天界面渲染（P10）
 
-- **mermaid 只在 message_end 全文到位时渲一次**，流式 delta 期间禁调（半截抛 parse error 闪烁）；失败保留原 `<pre>` + `.mermaid-error`。
-- **mermaid SVG 走手工 sanitize，不能换 DOMPurify**（DOMPurify 强制清空 `<foreignObject>`，mermaid v11 label 会被剥光）；安全靠 mermaid 自带 sanitize + CSP + 手工剥 `on*`/`javascript:` 三层兜底。
-- **挂件按 rel 去重**（防 live+history 双触发）；图片预览懒拉不 eager 内嵌（占位 `<img>` 后发 `download_file purpose=preview` 回包灌字节），SVG 走 pill 不内嵌；**切房 / clear 必 `clearPendingArtifactPreviews()`**（否则等待中的 `<img>` 已被摘走无处灌）。
-- **P10.1 数学/化学走 marked「转义前封箱」+ KaTeX live-DOM 延后渲**：行内扩展把整段 `$…$`/`$$…$$` 作单一 token 收走成 carrier span（否则 CommonMark 反斜杠转义先吃掉 `\,`/`\\`）；只认 `$`/`$$`，货币歧义 pandoc 风格收窄。
-- **KaTeX 在 DOMPurify 之后、只 message_end 调一次、逐公式独立 render**；`trust:false` + `throwOnError:false` + **不传 `macros`**（`\gdef` 不跨公式泄漏）。
-- **highlight.js v11 喂转义 textContent、单块单次、跳 mermaid/已高亮/未注册语言**；懒加载走 `@highlightjs/cdn-assets` ESM（**不能用 `highlight.js` 包的 CJS shim**，沙箱渲染进程无 CJS 互操作）。
-- **`enhanceContent` = mermaid + highlight + math 单钩子**（各自幂等），挂 `renderGuestText` / `endStreamingMessage` / `task_panel` goal 三注入点；流式 `appendDelta` 不调。P10.1 纯前端零后端改、不 bump `schema_version`、CSP 不改；打包须保 `katex/dist/fonts/`。
+见 `app/CLAUDE.md`（动 `app/` 下文件时自动加载）。
 
 ### 只读长期记忆（GuanLan MCP，P17）
 
@@ -281,4 +273,4 @@ Electron main (Node)  ─ spawn ─→  chahua-server (Python sidecar)
 
 ## 测试
 
-`asyncio_mode = "auto"` —— async 测试不用加 mark。`tests/` ~120 文件 / ~1380 测，覆盖 orchestrator / scoring / handoff / MTS / task / artifact / persona / server inbound / room runtime / P11 bg run。fixture 共享 `tests/conftest.py`（`build_orch` 裸构 Orchestrator / `SpeakingStubGuest` 走真 speak / `task_inbound_srv` 装真房间 + monkeypatch `_run_ai_chain` no-op）。**复现 bug 优先**，先写失败用例再修。全量 `uv run pytest`（~45s），单测 `uv run pytest tests/test_xxx.py -v`。
+fixture 共享 `tests/conftest.py`（`build_orch` 裸构 Orchestrator / `SpeakingStubGuest` 走真 speak / `task_inbound_srv` 装真房间 + monkeypatch `_run_ai_chain` no-op）。**复现 bug 优先**，先写失败用例再修。

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Quick Start
 
 ```bash
-# 1. python 依赖（uv 按 pyproject.toml 从 PyPI 拉 agentao ≥0.4.6）
+# 1. python 依赖（uv 按 pyproject.toml 从 PyPI 拉 agentao ≥0.4.18）
 uv sync
 
 # 2. LLM 凭据（任何 OpenAI-兼容 API 都行）

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -1,0 +1,13 @@
+# app/CLAUDE.md
+
+Electron 壳（`main/` / `preload/` / `renderer/`）承重不变量。仓库顶层 `CLAUDE.md` 是全局约定，本文件只在动 `app/` 下文件时加载。
+
+## 聊天界面渲染（P10）
+
+- **mermaid 只在 message_end 全文到位时渲一次**，流式 delta 期间禁调（半截抛 parse error 闪烁）；失败保留原 `<pre>` + `.mermaid-error`。
+- **mermaid SVG 走手工 sanitize，不能换 DOMPurify**（DOMPurify 强制清空 `<foreignObject>`，mermaid v11 label 会被剥光）；安全靠 mermaid 自带 sanitize + CSP + 手工剥 `on*`/`javascript:` 三层兜底。
+- **挂件按 rel 去重**（防 live+history 双触发）；图片预览懒拉不 eager 内嵌（占位 `<img>` 后发 `download_file purpose=preview` 回包灌字节），SVG 走 pill 不内嵌；**切房 / clear 必 `clearPendingArtifactPreviews()`**（否则等待中的 `<img>` 已被摘走无处灌）。
+- **P10.1 数学/化学走 marked「转义前封箱」+ KaTeX live-DOM 延后渲**：行内扩展把整段 `$…$`/`$$…$$` 作单一 token 收走成 carrier span（否则 CommonMark 反斜杠转义先吃掉 `\,`/`\\`）；只认 `$`/`$$`，货币歧义 pandoc 风格收窄。
+- **KaTeX 在 DOMPurify 之后、只 message_end 调一次、逐公式独立 render**；`trust:false` + `throwOnError:false` + **不传 `macros`**（`\gdef` 不跨公式泄漏）。
+- **highlight.js v11 喂转义 textContent、单块单次、跳 mermaid/已高亮/未注册语言**；懒加载走 `@highlightjs/cdn-assets` ESM（**不能用 `highlight.js` 包的 CJS shim**，沙箱渲染进程无 CJS 互操作）。
+- **`enhanceContent` = mermaid + highlight + math 单钩子**（各自幂等），挂 `renderGuestText` / `endStreamingMessage` / `task_panel` goal 三注入点；流式 `appendDelta` 不调。P10.1 纯前端零后端改、不 bump `schema_version`、CSP 不改；打包须保 `katex/dist/fonts/`。

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.10-dev",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.10-dev",
+      "version": "0.1.10",
       "dependencies": {
         "@highlightjs/cdn-assets": "^11.11.1",
         "dompurify": "^3.4.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.10-dev",
+  "version": "0.1.10",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.10.dev0"
+__version__ = "0.1.10"

--- a/docs/releases/v0.1.10.md
+++ b/docs/releases/v0.1.10.md
@@ -1,0 +1,49 @@
+# v0.1.10 —— 消息回溯与历史搜索（P18）+ 依赖大修（2026-07-30）
+
+继 v0.1.9「只读长期记忆（GuanLan MCP）+ MTS 管理者审计」之后第十一个版本。主线是 **P18 消息回溯与当前房历史搜索**——对齐用户提出的两个「豆包式」长期陪伴体验：发错消息能撤回重发、聊久了能按关键词搜历史并跳回那条。另一条线是**依赖大修**：agentao `0.4.14 → 0.4.18`（四个上游加固版本）+ MCP SDK `1.27.1 → 2.0.0`，chahua 侧零代码改动。1568 测试全过（v0.1.9 收线 1544 → +24）。
+
+## 亮点
+
+- **当前房历史搜索（纯读，便宜）**：右侧任务面板 header 的 🔍 入口（挨着 🔬 调试），输入关键词即出命中列表，点击滚动并高亮到那条消息。服务端 `search_room` → `SEARCH_RESULTS`，`re.escape` + `IGNORECASE` 原文子串匹配、query 长度封顶、results 只带 `speaker_id`。**不碰任何状态、不挡 inflight**——搜索顺着茶话室 append-only 的群聊模型走。
+- **消息回溯：撤回未回复的末条用户消息（逆着走，贵，故只做安全的那一刀）**：发错了、茶客还没接话，就能把它撤掉重发。**server 权威、免 `message_id`、无 payload**；三段硬校验缺一不可——房间 idle（用 `busy_alive()`，故 bg run 与 dormant MTS 也算忙）∧ transcript 末条存在且是用户消息 ∧「其后无茶客回复」（由前者蕴含）。
+- **回溯只截 transcript 主体，五套旁路状态同 tick 原子收尾**：`cancel_pending_summarize()` → 房间级 `Summarizer.truncate_after` → 遍历 store **全量任务**的 `TaskSummaries.truncate_after` → `TurnRecorder.drop_turns_from`，末尾重发整份 room snapshot。**cursor 与各茶客 `agent.messages` 一律不动**（顺手 `clear_history` / 回退游标即为 bug）。transcript 主体仍 append-only——`Room.truncate_last()` 是唯一全量重写入口（`write_jsonl_atomic` tmp+rename，**先写盘后弹内存**，写失败则内存与盘一致）。
+- **依赖大修，零代码改动**：agentao 四连跳带来打断安全、原子写、边界加固与 mcp 2.x 兼容；MCP SDK 推到 2.0.0 消掉「开发环境 1.x / 桌面包 2.x」的偏斜。两侧均经真 GuanLan 端到端实测。
+
+## 里程碑（按提交序）
+
+- **示例茶客孙博士：召回更像回忆、不像查资料**（提交 `78fce7e`）：纯 prompt 文本，重写「关于你的记性」段，顶住两股把茶客推向 reference-lookup 的系统力（MCP 工具动词 `search` / `read_page` + 每轮 `speak_instruction` 的「review tool results / re-fetch from source」）。四条纪律——无声地想（禁工具前旁白）/ 化整为言（抖掉标题、`[[链接]]`、日期骨架）/ 信心梯度（记得清→笃定、记得糊→自然含糊、全空→「没印象」即止）/ 禁词扩充 +3 组 ✗/✓ 范例。未动 `persona.toml` / `mcp.json` / 防注入 L3。
+- **P18 消息回溯 + 当前房历史搜索**（提交 `58ceea2`，详见 [`docs/P18-消息回溯与历史搜索导出.md`](../P18-消息回溯与历史搜索导出.md)）：
+  - **M1 当前房搜索**：只读 `search_room` inbound → `SEARCH_RESULTS` envelope；前端 `search_panel.js` + `search_panel.css` 新增，命中点击经 `jumpToMessage` 滚动高亮（对隐藏目标返 `false` 让调用方兜底）。
+  - **回溯**：`retract_last_user_message` inbound（`_reject_unknown_keys` 空白名单，`{type}` 裸帧合法）；`Room.truncate_last()` + `_persist.write_jsonl_atomic`；`Summarizer.truncate_after` / `TaskSummaries.truncate_after` / `TurnRecorder.drop_turns_from` 三条旁路收尾（summary 收尾包 try/except）。
+  - **前端撤回按钮**动态挂唯一「当前可撤回」用户气泡：MutationObserver + `endStreamingMessage` 双触发，跳过 `.sys` / `.error`。
+  - 承重不变量同步进 `CLAUDE.md` + [`docs/INVARIANTS.md`](../INVARIANTS.md) §9.x；经 workflow xhigh code-review + Codex 5 轮 review 收敛至 clean。
+- **`CLAUDE.md` 瘦身 + 修正漂移**（提交 `500eee8`）：「关键不变量」段只留「规则 + 关键 why」，MTS / P11 完整 rationale 下沉 `docs/INVARIANTS.md`；模块分工表精练到「一句话职责」。
+- **依赖 agentao `0.4.14 → 0.4.18` + MCP SDK `1.27.1 → 2.0.0`**（本版收尾）：见下「依赖」段。
+
+## 模块新增 / 改动
+
+- **P18 后端**：`chahua/room.py`（`truncate_last`）、`chahua/_persist.py`（`write_jsonl_atomic`）、`chahua/summarizer.py`（`truncate_after` + `cancel_pending_summarize`）、`chahua/debug_recorder.py`（`drop_turns_from`）、`chahua/server.py` + `chahua/server_inbound_io.py`（两个新 inbound）、`chahua/events.py`（`SEARCH_RESULTS`）、`chahua/orchestrator.py`。
+- **P18 前端**：新增 `app/renderer/search_panel.js` + `styles/search_panel.css`；改 `chat_stream.js` / `chat_view.js` / `envelope_router.js` / `events.js` / `renderer.js` / `index.html` / `styles/chat.css`。
+- **P18 测试**：新增 `tests/test_retract_last_user_message.py` + `tests/test_search_room.py`（合计 +24）。
+- **依赖**：`pyproject.toml`（`agentao>=0.4.18`）+ `uv.lock`（agentao 0.4.18 / mcp 2.0.0 + `mcp-types` / `httpx2` / `truststore`；移除 `httpx-sse` / `pydantic-settings`）。
+
+## 依赖
+
+- **agentao `0.4.14 → 0.4.18`**，四个上游版本全是加固 / 修正，chahua 侧零代码改动：
+  - `0.4.15` 会话与文件完整性：`Ctrl+C` 打断的 turn 不再让后续每轮 400；`write_file` 改 tmp+rename 原子替换；无回答的 turn 被分类而非当答案发；secret 扫描器挪上实时路径。
+  - `0.4.16` 边界加固：ACP 客户端首审、`web_search` 撞 captcha 不再静默报「无结果」、MCP 请求带 UA。
+  - `0.4.17` SDK 兼容：上游 `mcp` 2.0.0 破坏性重写线上模型，会让 `0.4.16` 的**全部 MCP 路径**在新装环境上炸；`0.4.18` 用 `_compat` 探针同时支持 mcp 1.x / 2.x 并收敛到 `>=1.26.0,<3`。
+  - `0.4.18` `web_fetch` 重建（crawl4ai → Playwright + SSRF 加固）并改 `AsyncToolBase`；`Agentao.arun` 改用专属线程池。
+- **MCP SDK `1.27.1 → 2.0.0`**：动机是消掉「开发环境 1.x / 桌面包 2.x」的偏斜（打包走 `pip install`、不读 `uv.lock`）。全仓唯一直接触 SDK 的地方是 `chahua/mcp_thread.py` 的 `from mcp.types import Tool`，**只作类型标注、不读字段**，故 2.0 的 camelCase→snake_case 重命名碰不到。真 GuanLan 端到端实测（guanlan 0.1.18 / 服务端 mcp 2.0.0）：客户端 1.27.1 与 2.0.0 各跑一遍均 6 工具全列 / schema 全取到 / `search` 往返 / 干净拆除。
+
+## ⚠️ 升级注意
+
+- **茶客子进程不再继承 provider 凭证**（随 agentao `0.4.15`）：shell / **stdio 型 MCP** / ACP 子进程从被擦洗的环境启动（12 个 `HARNESS_ENV_KEYS` + `LLM_PROVIDER` 隐含的那把 key）。**若你的某个 stdio MCP server 原先靠继承 `*_API_KEY` 工作，升级后会拿到 401**——在该 server 的 `env` 块显式声明（`{"env": {"XX_API_KEY": "${XX_API_KEY}"}}`，擦洗之后才应用），或设 `AGENTAO_SCRUB_CHILD_ENV=0` 全进程恢复继承。P17 GuanLan 走 url 型 Streamable HTTP（不是子进程）**不受影响**。
+
+## 已知未做
+
+- **P18 只做了「撤回未回复的末条」，没做「有回复后回溯 / 编辑重生成」**：后者要同时回滚**五套状态**，而根因不在文件格式，在「N 个茶客各持一份烘死的私有记忆」这个群聊模型本身——现状只有 `reset_room` 能一起全清、无部分回退原语。
+- **P18 M1.5 / M2 仍为设计**：导出过滤与元数据（`export_room` 整房 markdown 导出本身早已可用）、全局 / 正则 / 跨房搜索。
+- **搜索是原文子串匹配，不是语义检索**：`re.escape` + `IGNORECASE`，不分词、不排序相关度。
+- **chahua 落在 MCP 握手协议纪元（`2025-11-25`）**：mcp 2.0 的 modern 纪元（`2026-07-28`）只经无握手的信封路径可达，而 agentao 的 `McpClient` 显式走 `ClientSession.initialize()`。升到 mcp 2.0.0 只是获得了说新协议的能力，实际线协议未变——要动得改 agentao 侧。
+- **packaged 安装包未 Apple Developer ID 签名**：.dmg 仍未签名（同 v0.1.3 ~ v0.1.9），首次启动需用户在「系统设置 → 隐私与安全性」放行。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "chahua"
-version = "0.1.10.dev0"
+version = "0.1.10"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
-    "agentao>=0.4.14",
+    "agentao>=0.4.18",
     "python-dotenv>=1.0",
     "websockets>=13",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,14 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "agentao"
-version = "0.4.14"
+version = "0.4.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -16,9 +20,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/a5/b7b9fdccf4a6d8c75beb937bf9c98c529c86e0e2d2bb47125935c51908f7/agentao-0.4.14.tar.gz", hash = "sha256:c2d884c28feda494ed107bebd240b77925c38604d8d2e29b4235326abb6f3618", size = 1009721, upload-time = "2026-07-02T03:12:05.143Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/77/ef631fbe2c74dda1a9f67d416d11e486b0c7a8c0df7cdf9f4f89d11652dd/agentao-0.4.18.tar.gz", hash = "sha256:850283d16c0ecc6d2c05a4623fc126c5a32cf2d69968ff5b3298928e96ca1d9f", size = 944744, upload-time = "2026-07-30T13:07:57.909Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/3e/26167c5982cd1952dd1f99461a1bf332ce0bd1b6b7491d56a1a122eb59b4/agentao-0.4.14-py3-none-any.whl", hash = "sha256:f669cd8baa7dfd066c81d8b415a25fc3187b65022975a770d3366e68ee9313df", size = 821357, upload-time = "2026-07-02T03:12:03.562Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2c/30ae4e568e79725b5c9e612c6571b893fad7d9bbdf5b99da53c238d708dd/agentao-0.4.18-py3-none-any.whl", hash = "sha256:4f276b41156d9775738f06167c1695488df6347feb812674a1cdfad5c1eac0f5", size = 885733, upload-time = "2026-07-30T13:07:56.391Z" },
 ]
 
 [[package]]
@@ -133,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "chahua"
-version = "0.1.10.dev0"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "agentao" },
@@ -149,7 +153,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agentao", specifier = ">=0.4.14" },
+    { name = "agentao", specifier = ">=0.4.18" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "websockets", specifier = ">=13" },
 ]
@@ -281,6 +285,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -296,21 +313,28 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -527,15 +551,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -545,9 +569,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -567,6 +604,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -711,20 +760,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
 ]
 
 [[package]]
@@ -1038,6 +1073,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
发布 v0.1.10 的准备工作。**无功能改动** —— P18 本体已随 `58ceea2` 合入，本 PR 只补发布所需的文档 / 版本号 / 依赖收尾。

## 为什么开这个 PR

盘点发布前置时发现 `[Unreleased]` 段**只有依赖条目**，这一版的头条功能 P18（消息回溯 + 当前房搜索）在 CHANGELOG 里完全没有记录；同时 `CLAUDE.md` 的进一步瘦身与新文件 `app/CLAUDE.md` 一直遗留在工作区未提交（而 `CLAUDE.md` 对后者的引用也只在工作区，两者必须一起进）。

## 改了什么

1. **CHANGELOG 补齐**：P18（Added）+ 孙博士 persona 召回口径改进、`CLAUDE.md` 瘦身（Changed）。
2. **新增 `docs/releases/v0.1.10.md`**，体例对齐 `v0.1.9.md`（亮点 / 里程碑按提交序 / 模块改动 / 依赖 / 升级注意 / 已知未做）。
3. **`[Unreleased]` → `## [0.1.10] - 2026-07-30`**，加指向 release notes 的一行，上方留空 `[Unreleased]`。
4. **版本号五处去 dev 后缀 → `0.1.10`**：`pyproject.toml` / `chahua.__version__` / `app/package.json` / `app/package-lock.json`（两处）/ `uv.lock` 自包条目；`uv lock --check` 通过。
5. **依赖升级落地**：`agentao 0.4.14 → 0.4.18`、`mcp 1.27.1 → 2.0.0`。chahua 侧**零代码改动**（全仓唯一直接触 MCP SDK 的 `chahua/mcp_thread.py` 只把 `mcp.types.Tool` 用作类型标注、不读字段）。
6. **README 修漂移**：`agentao ≥0.4.6` → `≥0.4.18`。

## ⚠️ 一个用户可见的行为变化（随 agentao 0.4.15）

茶客子进程不再继承 provider 凭证：shell / **stdio 型 MCP** / ACP 子进程从被擦洗的环境启动。**若某个 stdio MCP server 原先靠继承 `*_API_KEY` 工作，升级后会拿到 401** —— 需在该 server 的 `env` 块显式声明，或设 `AGENTAO_SCRUB_CHILD_ENV=0`。P17 GuanLan 走 url 型 Streamable HTTP（不是子进程）不受影响。已写进 release notes 的「升级注意」段。

## 验证

- 全量 **1568 测试绿**（v0.1.9 收线 1544 → +24，与 P18 落地吻合）
- **端到端实测**：真 `guanlan mcp --transport http`（guanlan 0.1.18 / 服务端 mcp 2.0.0），客户端 mcp 1.27.1 与 2.0.0 各跑一遍，均 6 工具全列 / schema 全取到 / `search` 往返真数据 / 干净拆除
- **已打包**：`FORCE=1 npm run build:mac` → `chahua-0.1.10-mac-arm64.dmg`（155M）。bundle 内复核 `chahua 0.1.10` / `agentao 0.4.19.dev0`（本地源）/ **`mcp 2.0.0`** —— 开发环境与桌面包的 mcp 大版本偏斜就此消掉

## 合并后

打 annotated tag `v0.1.10` → `gh release create v0.1.10 <dmg> --notes-file docs/releases/v0.1.10.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)