### PR TITLE
chore: 进入开发态 0.1.10 → 0.1.11.dev0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chahua-app",
-  "version": "0.1.10",
+  "version": "0.1.11-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chahua-app",
-      "version": "0.1.10",
+      "version": "0.1.11-dev",
       "dependencies": {
         "@highlightjs/cdn-assets": "^11.11.1",
         "dompurify": "^3.4.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chahua-app",
-  "version": "0.1.10",
+  "version": "0.1.11-dev",
   "private": true,
   "description": "茶话室 桌面壳（P3.1：Electron + chahua-server sidecar）",
   "main": "main/index.js",

--- a/chahua/__init__.py
+++ b/chahua/__init__.py
@@ -4,4 +4,4 @@ P0 骨架：Room + TeaGuest + USER.md + 单茶客流式 CLI。
 完整设计见 docs/DESIGN.md。
 """
 
-__version__ = "0.1.10"
+__version__ = "0.1.11.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chahua"
-version = "0.1.10"
+version = "0.1.11.dev0"
 description = "茶话室 —— 多 Agent 群聊桌面 App"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "chahua"
-version = "0.1.10"
+version = "0.1.11.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agentao" },


### PR DESCRIPTION
v0.1.10 已发布（[release](https://github.com/jin-bo/chahua/releases/tag/v0.1.10)），按惯例把版本号挂回开发态后缀。

版本号五处：`pyproject.toml`、`chahua/__init__.py`、`app/package.json`、`app/package-lock.json`（顶层 + `packages.""`）、`uv.lock`（chahua 自包条目）。`uv lock --check` 通过，全量 1568 测试绿。

`CHANGELOG.md` 的空 `[Unreleased]` 段已在 v0.1.10 收尾时就位，本 PR 不动它。

🤖 Generated with [Claude Code](https://claude.com/claude-code)