### PR TITLE
docs: 补 v0.1.11 打包实测事实 + P10.2 asar 核验口径

### DIFF
--- a/docs/P10.2-flint 数据图表渲染.md
+++ b/docs/P10.2-flint 数据图表渲染.md
@@ -841,7 +841,7 @@ Electron，故分两层——**node 层锁「静态契约与纯函数」**，**E
 - [x] **打包资产核验**：`cd app && npm run build:dir` 后 `npx asar list` 核
       `dist/mac*/茶话室.app/Contents/Resources/app.asar` **含**
       `node_modules/flint-chart/dist/echarts/index.js` + `node_modules/echarts/dist/echarts.esm.min.js`，
-      **不含** `echarts/lib/**` / `echarts/dist/echarts.esm.js`（3.4 M 未压缩）/ 任何 `*.map` /
+      **不含** `echarts/lib/**` / `echarts/dist/echarts.esm.js`（3.4 M 未压缩）/ 这两个包的任何 `*.map`（asar 里另有 84 个 `.map` 属既有依赖 mermaid / dompurify / marked 等，与本相位无关，别核成全局零）/
       flint 的 `plotly`/`chartjs`/`vegalite`/`excel`/`test-data`/`gallery` dist。核 asar 体积增量 ≈ 1.65 MB。
 
 ### Electron 验收（发版前 checklist）

--- a/docs/releases/v0.1.11.md
+++ b/docs/releases/v0.1.11.md
@@ -33,6 +33,8 @@
 
 - **npm 新增两个直接依赖，均钉版无 `^`**：`flint-chart@0.4.1` + `echarts@6.1.0`（与观澜 P4.20 钉同一份，两仓行为一致）。两者都是**自包含浏览器 ESM**，无 bare import / 无 `require(` / 无 `process.` —— 这条由 `flint_core.test.mjs` 里一条常驻用例机械断言，**升级钉版必跑**（另有 37 图型不误杀扫描与语义色 grep）。
 - **Python 依赖零变化**：`agentao>=0.4.18` 不变，`uv.lock` 仅版本号自包更新。
+- **打包 bundle 里的 agentao 与开发环境有偏斜（一贯如此，此处记明）**：`build-python-bundle.js` 把本地 `../agentao` **源码**非 editable 装进 bundle，故 dmg 里是 `0.4.20.dev0`（内容 = 已发布的 **0.4.19** + 开发周期版本号 bump，`../agentao` 在 `v0.4.19` 之后只有那一个 chore 提交）；而 `uv.lock` / dev venv / 本版 1576 条测试跑的是 PyPI **0.4.18**。两者都满足 `>=0.4.18`。0.4.19 是纯修正版本，其中 **shell hardline 越权绕过**（`timeout 5 rm -rf /` 一类 wrapper 形态可绕过高于一切 mode preset 与用户规则的底线）与 **MCP `tools/list` 分页丢失第 2 页起的工具**两条对桌面包尤其有意义。
+- **本版 `FORCE=1` 是必须的，不是保险起见**：`build-python-bundle.js` 在 `finalPyExe` 已存在且非 FORCE 时**直接 return**，而 bundle 是把 chahua 源码 pip 非 editable 装进去的 —— 不 FORCE 会把上一版的 python 打进 dmg，**P8.7 整个不在包里**。打包后已核 bundle 内 `chahua.__version__ == "0.1.11"`。
 
 ## ⚠️ 升级注意
 


### PR DESCRIPTION
打包跑完后核出来的两条事实，趁打 tag 之前落进发布说明，这样 tag 上的 `docs/releases/v0.1.11.md` 是完整的。

## 1. bundle 里的 agentao 与开发环境有偏斜（一贯如此，此处记明）

| | 版本 | 来源 |
|---|---|---|
| dmg 里的 bundle | `0.4.20.dev0` | 本地 `../agentao` **源码**（pip 非 editable 装） |
| `uv.lock` / dev venv / 本版 1576 条测试 | `0.4.18` | PyPI |

`0.4.20.dev0` 的**内容 = 已发布的 0.4.19 + 开发周期版本号 bump** —— `../agentao` 在 `v0.4.19` 之后只有那一个 chore 提交，工作区干净。两者都满足 `agentao>=0.4.18`。0.4.19 是纯修正版本，其中 **shell hardline 越权绕过**与 **MCP `tools/list` 分页丢失第 2 页起的工具**两条对桌面包尤其有意义。

## 2. 本版 `FORCE=1` 是必须的，不是保险起见

`build-python-bundle.js` 在 `finalPyExe` 已存在且非 FORCE 时**直接 `return`**，而 bundle 是把 chahua 源码 pip 非 editable 装进去的 —— 不 FORCE 会把上一版的 python 打进 dmg，**P8.7 整个不在包里**。已核 bundle 内 `chahua.__version__ == "0.1.11"`。

## 3. 顺带修 P10.2 §7 打包核验一行的口径

原文写「**不含** … 任何 `*.map`」，实测会被误读成全局零：asar 里另有 **84 个 `.map`** 属既有依赖（mermaid 66 / import-meta-resolve 6 / dompurify 4 / ts-dedent 2 / stylis 2 / mermaid 2 / marked 2），与本相位无关。改写成「这两个包的任何 `*.map`」。

实测核过（asar 48,828,724 bytes）：

- **应在**：`flint-chart/dist/echarts/index.js`、`echarts/dist/echarts.esm.min.js`、`renderer/flint_core.mjs`、`renderer/flint_chart.js`
- **应不在，实测计数均为 0**：`echarts/lib` / `echarts.esm.js` / `zrender` / `tslib` / `*.test.mjs` / `scripts/flint-smoke`
- flint-chart 与 echarts **进包的就是那两个 dist 文件**，别无其他

🤖 Generated with [Claude Code](https://claude.com/claude-code)
